### PR TITLE
Fix: Skip Multiple Sequential Tracks

### DIFF
--- a/models/snip/snip.js
+++ b/models/snip/snip.js
@@ -51,12 +51,23 @@ class Snip {
         return this._store.getTrack(this.defaultTrack)
     }
 
+    get nextButton() {
+        return document.querySelector('[data-testid="control-button-skip-forward"]')
+    }
+
     load() {
         this._video.volume = 0
 
         const response = this.read()
+
         if (response?.isSnip) {
-            this.loadSnip(response)
+            // if skippable song
+            if (response?.endTime == 0) {
+                this._video.currentTime = playback.duration() + 1 
+                return this.nextButton?.click()
+            } else {
+                this.loadSnip(response)
+            }
         }
 
         this._video.volume = 1


### PR DESCRIPTION
This is a fix/feature where multiple snips in a row, such as from an album or playlist, can be skipped properly. Currently, the first one is skipped and then the followings ones are immediately played. Additionally, it would error a play promise rejected due to a track being paused while a play promise is pending.

Here's a showcase where the entire Speak Now (Taylor's Version) tracks are skippable.

![chorus-skip](https://github.com/cdrani/chorus/assets/18746599/b8ab1e58-1261-4766-80d8-acac53eb9cbe)
