### PR TITLE
Fix: Next & Previous Buttons Cause Early Starts

### DIFF
--- a/models/skip.js
+++ b/models/skip.js
@@ -77,10 +77,12 @@ class Skip {
         const skipIcon = row.querySelector('button[role="blocker"]')
         skipIcon.style.display = 'block'
 
-        const { id, endTime } = this.#songInfo(row)
+        const song = this.#songInfo(row)
+        if (!song) return
+
         const { isSkipped } = this.#store.getTrack({ 
-            id,
-            value: { isSkipped: false, isSnip: false, startTime: 0, endTime }
+            id: song.id,
+            value: { isSkipped: false, isSnip: false, startTime: 0, endTime: song.endTime }
         })
 
         this.#setHighlighted({ isSkipped, skipIcon })
@@ -127,7 +129,10 @@ class Skip {
 
     #songInfo(row) {
         const song = row.querySelector('a > div')?.textContent || row.querySelector('div[data-encore-id="type"]')?.textContent
-        const songLength = row.querySelector('button[data-testid="add-button"] + div').textContent
+        const songLength = row.querySelector('button[data-testid="add-button"] + div')?.textContent
+
+        if (!songLength) return
+
         const artists = this.#getArtists(row)
 
         return {

--- a/observers/current-time.js
+++ b/observers/current-time.js
@@ -22,8 +22,27 @@ class CurrentTimeObserver {
         }
     }
 
+    #handleClick = (e) => {
+        e.preventDefault()
+        if (!this.#muted) this.#muteButton.click()
+    }
+
+    #setListeners() {
+        this.#nextButton?.addEventListener('click', this.#handleClick)
+        this.#previousButton?.addEventListener('click', this.#handleClick)
+    }
+
+    #clearListeners() {
+        this.#nextButton?.removeEventListener('click', this.#handleClick)
+        this.#previousButton?.removeEventListener('click', this.#handleClick)
+    }
+
     get #playbackPosition() {
         return document.querySelector('[data-testid="playback-position"]')
+    }
+
+    get #previousButton() {
+        return document.querySelector('[data-testid="control-button-skip-back"]')
     }
 
     get #nextButton() {
@@ -81,6 +100,8 @@ class CurrentTimeObserver {
     }
 
     observe() {
+        this.#setListeners()
+
         this.#observer = setInterval(() => {
             const { isSkipped, isSnip, startTime, endTime } = this.#songState
 
@@ -124,6 +145,7 @@ class CurrentTimeObserver {
         if (!this.#observer) return
 
         clearInterval(this.#observer)
+        this.#clearListeners()
         this.#observer = null
     }
 }


### PR DESCRIPTION
Sets up click event listeners on Next and Previous buttons to mute the track. These listeners are removed on Action toggle off.

closes #16 