### PR TITLE
Fix: Snip Actions Errors

### DIFF
--- a/models/snip/current-snip.js
+++ b/models/snip/current-snip.js
@@ -42,6 +42,7 @@ export default class CurrentSnip extends Snip {
 
     async save() {
         const { inputLeft, inputRight } = this._controls.slider.elements
+        const { isSkipped } = this.read()
 
         await this._store.saveTrack({
             id: currentSongId(),
@@ -49,7 +50,7 @@ export default class CurrentSnip extends Snip {
                 isSnip: true,
                 startTime: inputLeft.value,
                 endTime: inputRight.value,
-                ... inputRight.value == 0 && { isSkipped: true },
+                isSkipped: inputRight.value == 0 || isSkipped,
             },
         })
 

--- a/models/snip/snip-controls.js
+++ b/models/snip/snip-controls.js
@@ -9,6 +9,10 @@ export default class SnipControls {
         this._controls.init()
     }
 
+    get slider() {
+        return  this._controls.slider
+    }
+
     setInitialValues(track) {
         this._controls.setInitialValues(track)
     }

--- a/models/snip/snip.js
+++ b/models/snip/snip.js
@@ -2,10 +2,8 @@ import SnipControls from './snip-controls.js'
 import ButtonListeners from '../../events/listeners.js'
 
 export default class Snip {
-    #store
-
     constructor(store) {
-        this.#store = store
+        this._store = store
         this._controls = new SnipControls()
         this._listeners = new ButtonListeners(this)
     }
@@ -15,7 +13,7 @@ export default class Snip {
     }
 
     read() {
-        return this.#store.getTrack(this._defaultTrack)
+        return this._store.getTrack(this._defaultTrack)
     }
 
     reset() {
@@ -23,8 +21,8 @@ export default class Snip {
     }
 
     async delete() {
-        await this.#store.deleteTrack(this._defaultTrack)
-        this.updateView()
+        await this._store.deleteTrack(this._defaultTrack)
+        this._updateView()
     }
 
     _updateView() {

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -37,12 +37,15 @@ export default class TrackSnip extends Snip {
     }
 
     _highlightSnip(isSnip) {
-        const svgElement = document.getElementById('chorus-highlight')
-        const fill = Boolean(isSnip) ? '#1ed760' : 'currentColor'
+        const svgElement = this.#row.querySelector('svg[role="snip"]')
+        const fill = isSnip ? '#1ed760' : 'currentColor'
 
         if (!svgElement) return
 
-        svgElement.style.stroke = fill
+        svgElement.style.color = fill
+
+        const icon = this.#row.querySelector('button[role="snip"]')
+        icon.style.visibility = isSnip ? 'visible' : 'hidden'
     }
 
     async save() {

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -47,14 +47,15 @@ export default class TrackSnip extends Snip {
 
     async save() {
         const { inputLeft, inputRight } = this._controls.slider.elements
+        const { isSkipped } = this.read()
 
         await this._store.saveTrack({
-            id: trackSongInfo(row).id,
+            id: trackSongInfo(this.#row).id,
             value: {
                 isSnip: true,
                 startTime: inputLeft.value,
                 endTime: inputRight.value,
-                ... inputRight.value == 0 && { isSkipped: true },
+                isSkipped: inputRight.value == 0 || isSkipped,
             },
         })
 

--- a/stores/data.js
+++ b/stores/data.js
@@ -55,7 +55,7 @@ export default class DataStore {
             detail: { key: id },
         })
 
-        this.#cache.update({ key: id, value })
+        this.#cache.update({ key: id, value: { ...value, isSnip: false } })
         return this.#cache.getKey(id)
     }
 }


### PR DESCRIPTION
1. Brings back functionality like `save` and `remove` in Chorus modal. 
2. Update highlight logic for track snip to immediately highlight/unhighlight the track Settings icon on `save` or `remove` actions
3. Set default `isSkipped` value for snip `save` action

closes #31 