### PR TITLE
Feat: Share Track Snip

### DIFF
--- a/actions/init.js
+++ b/actions/init.js
@@ -73,7 +73,15 @@ class App {
     }
 }
 
-setTimeout(async () => {
+const setup = setInterval(async () => {
+    const nowPlayingWidget = document.querySelector('[data-testid="now-playing-widget"]')
+    if (!nowPlayingWidget) return
+
+    await load()
+    clearInterval(setup)
+}, 500)
+
+async function load() {
     const store = new DataStore()
     const video = spotifyVideo.element
 
@@ -85,4 +93,4 @@ setTimeout(async () => {
         const { enabled } = e.detail
         enabled ? app.connect() : app.disconnect()
     })
-}, 2500)
+}

--- a/actions/main.js
+++ b/actions/main.js
@@ -1,6 +1,8 @@
 import Icon from '../models/icon.js'
 import Chorus from '../models/chorus.js'
 
+import { createAlert } from '../components/alert.js'
+
 export default class Main {
     #icon
     #snip
@@ -16,6 +18,7 @@ export default class Main {
 
     init() {
         this.#placeIcon()
+        this.#setupAlert()
     }
 
     #placeIcon() {
@@ -31,6 +34,19 @@ export default class Main {
 
             clearInterval(interval)
         }, 50)
+    }
+
+    #handleAlert({ e, target }) {
+        e.stopPropagation()
+        const container = target.parentElement
+        container.style.display = 'none'
+    }
+
+    #setupAlert() {
+        document.body.insertAdjacentHTML('beforeend', createAlert()) 
+
+        const closeAlert = document.getElementById('chorus-alert-close-button')
+        closeAlert?.addEventListener('click', (e) => this.#handleAlert({ e, target: closeAlert }))
     }
 
     get element() {

--- a/components/alert.js
+++ b/components/alert.js
@@ -1,0 +1,21 @@
+export const createAlert = () => `
+    <div 
+        id="chorus-alert"
+        style="display:none;justify-content:space-between;align-items:center;border-radius:.5rem;z-index:99999;padding:.5rem 1.25rem;padding-right:.75rem;min-width:320px;width:60%;background:#1ed670;position:absolute;bottom:10%;right:2.5%;"
+    >
+        <p id="chorus-alert-message" style="font-size:1.25rem;color:#fff;"></p>
+        <button id="chorus-alert-close-button" class="chorus-text-button" style="padding:.5rem;align-self:center;background:none;border:none">
+            <svg 
+                role="img"
+                fill="none"
+                width="24px"
+                height="24px"
+                stroke="#fff"
+                stroke-width="2"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    </div>
+`

--- a/components/buttons.js
+++ b/components/buttons.js
@@ -1,20 +1,29 @@
 export const createActionButtons = () => `
-    <div style="display:flex;justify-content:flex-end; margin-top:12px">
-        <div style="display:flex;align-items:center;justify-content:space-between">
-            <button
-                class="chorus-text-button"
-                id="chorus-remove-button"
-                style="display:none;padding:0 10px;height:100%;margin-right:0.5rem;font-size:1rem;"
-            >
-                <span>remove</span>
-            </button>
-            <button
-                id="chorus-save-button"
-                class="chorus-text-button"
-                style="font-size:1rem;padding:0 10px;height:100%;"
-            >
-                <span>save</span>
-            </button>
+    <div style="display:flex;margin-top:12px;justify-content:space-between">
+        <button
+            class="chorus-text-button"
+            id="chorus-share-button"
+            style="display:flex;padding:0 10px;height:100%;font-size:1rem;"
+        >
+            <span>share</span>
+        </button>
+        <div style="display:flex;justify-content:flex-end">
+            <div style="display:flex;align-items:center;justify-content:space-between">
+                <button
+                    class="chorus-text-button"
+                    id="chorus-remove-button"
+                    style="display:none;padding:0 10px;height:100%;margin-right:0.5rem;font-size:1rem;"
+                >
+                    <span>remove</span>
+                </button>
+                <button
+                    id="chorus-save-button"
+                    class="chorus-text-button"
+                    style="font-size:1rem;padding:0 10px;height:100%;"
+                >
+                    <span>save</span>
+                </button>
+            </div>
         </div>
     </div>
 `

--- a/components/header.js
+++ b/components/header.js
@@ -1,7 +1,7 @@
 export const createHeader = () => `
     <div class="chorus-common">
         <span class="chorus-header">chorus</span>
-        <button id="chorus-close-button" class="chorus-text-button">
+        <button id="chorus-modal-close-button" class="chorus-close-button">
             <svg 
                 role="img"
                 fill="none"

--- a/content-script.js
+++ b/content-script.js
@@ -12,6 +12,7 @@ const scripts = [
     'actions/overload.js',
     'utils/time.js',
     'utils/playback.js',
+    'utils/clipboard.js',
     'components/buttons.js',
     'components/header.js',
     'components/labels.js',

--- a/events/listeners.js
+++ b/events/listeners.js
@@ -12,6 +12,7 @@ export default class ButtonListeners {
     init() {
         this.#closeListener()
         this.#saveTrackListener()
+        this.#shareTrackListener()
         this.#deleteTrackListener()
     }
 
@@ -36,6 +37,14 @@ export default class ButtonListeners {
         const saveButton = document.getElementById('chorus-save-button')
         saveButton?.addEventListener('click', async () => {
             await this.#snip.save()
+            this.#hide()
+        }, { once: true })
+    }
+
+    #shareTrackListener() {
+        const shareButton = document.getElementById('chorus-share-button')
+        shareButton?.addEventListener('click', () => {
+            this.#snip.share()
             this.#hide()
         }, { once: true })
     }

--- a/events/listeners.js
+++ b/events/listeners.js
@@ -10,7 +10,7 @@ export default class ButtonListeners {
     }
 
     init() {
-        this.#closeListener()
+        this.#closeModalListener()
         this.#saveTrackListener()
         this.#shareTrackListener()
         this.#deleteTrackListener()
@@ -20,8 +20,8 @@ export default class ButtonListeners {
         this.#chorus.hide()
     }
 
-    #closeListener() {
-        const closeButton = document.getElementById('chorus-close-button')
+    #closeModalListener() {
+        const closeButton = document.getElementById('chorus-modal-close-button')
         closeButton?.addEventListener('click', () => this.#hide(), { once: true })
     }
 

--- a/events/listeners.js
+++ b/events/listeners.js
@@ -41,11 +41,15 @@ export default class ButtonListeners {
         }, { once: true })
     }
 
+    #handleShare = e => {
+        e.stopPropagation()
+        this.#snip.share()
+        this.#hide()
+    }
+
     #shareTrackListener() {
         const shareButton = document.getElementById('chorus-share-button')
-        shareButton?.addEventListener('click', () => {
-            this.#snip.share()
-            this.#hide()
-        }, { once: true })
+        shareButton?.removeEventListener('click', this.#handleShare)
+        shareButton?.addEventListener('click', this.#handleShare)
     }
 }

--- a/events/listeners.js
+++ b/events/listeners.js
@@ -21,7 +21,7 @@ export default class ButtonListeners {
 
     #closeListener() {
         const closeButton = document.getElementById('chorus-close-button')
-        closeButton?.addEventListener('click', () => this.#hide())
+        closeButton?.addEventListener('click', () => this.#hide(), { once: true })
     }
 
     #deleteTrackListener() {
@@ -29,7 +29,7 @@ export default class ButtonListeners {
         deleteButton?.addEventListener('click', async () => {
             await this.#snip.delete()
             this.#hide()
-        })
+        }, { once: true })
     }
 
     #saveTrackListener() {
@@ -37,6 +37,6 @@ export default class ButtonListeners {
         saveButton?.addEventListener('click', async () => {
             await this.#snip.save()
             this.#hide()
-        })
+        }, { once: true })
     }
 }

--- a/events/listeners.js
+++ b/events/listeners.js
@@ -1,8 +1,12 @@
+import Chorus from '../models/chorus.js'
+
 export default class ButtonListeners {
     #snip
+    #chorus
 
     constructor(snip) {
         this.#snip = snip
+        this.#chorus = new Chorus()
     }
 
     init() {
@@ -12,8 +16,7 @@ export default class ButtonListeners {
     }
 
     #hide() {
-        const main = document.getElementById('chorus-main')
-        main.style.display = 'none'
+        this.#chorus.hide()
     }
 
     #closeListener() {

--- a/models/slider/slider.js
+++ b/models/slider/slider.js
@@ -2,7 +2,7 @@ import { spotifyVideo } from '../../actions/overload.js'
 
 import { playback } from '../../utils/playback.js'
 import { secondsToTime } from '../../utils/time.js'
-import { currentSongId } from '../../utils/song.js'
+import { currentSongInfo } from '../../utils/song.js'
 
 export default class Slider {
     #isCurrentlyPlaying = true
@@ -33,7 +33,7 @@ export default class Slider {
     }
 
     setInitialValues(track) {
-        this.#isCurrentlyPlaying = !track?.id ? true : track.id == currentSongId()
+        this.#isCurrentlyPlaying = !track?.id ? true : track.id == currentSongInfo().id
 
         const { endTime, startTime } = track
         const { endDisplay } = this.elements

--- a/models/snip/current-snip.js
+++ b/models/snip/current-snip.js
@@ -1,7 +1,8 @@
 import Snip from './snip.js'
 
 import { playback } from '../../utils/playback.js'
-import { currentSongId } from '../../utils/song.js'
+import { currentSongInfo } from '../../utils/song.js'
+import { copyToClipBoard } from '../../utils/clipboard.js'
 
 export default class CurrentSnip extends Snip {
     constructor(store) {
@@ -17,7 +18,7 @@ export default class CurrentSnip extends Snip {
 
     get _defaultTrack() {
         return {
-            id: currentSongId(),
+            id: currentSongInfo().id,
             value: {
                 startTime: 0,
                 isSnip: false,
@@ -41,7 +42,17 @@ export default class CurrentSnip extends Snip {
     }
 
     share() {
-        // TODO: implement
+        const { url } = currentSongInfo()
+        const { startTime, endTime } = this.read()
+        
+        const shareURL = `${url}?startTime=${startTime}&endTime=${endTime}`
+        copyToClipBoard(shareURL)
+
+        const alertBox = document.getElementById('chorus-alert') 
+        const alertMessage = alertBox.querySelector('[id="chorus-alert-message"]')
+        alertMessage.textContent = `Snip copied to clipboard.`
+        alertBox.style.display = 'flex' 
+        setTimeout(() => { alertBox.style.display = 'none' }, 3000)
     }
 
     async save() {
@@ -49,7 +60,7 @@ export default class CurrentSnip extends Snip {
         const { isSkipped } = this.read()
 
         await this._store.saveTrack({
-            id: currentSongId(),
+            id: currentSongInfo().id,
             value: {
                 isSnip: true,
                 startTime: inputLeft.value,

--- a/models/snip/current-snip.js
+++ b/models/snip/current-snip.js
@@ -40,6 +40,10 @@ export default class CurrentSnip extends Snip {
         svgElement.style.stroke = fill
     }
 
+    share() {
+        // TODO: implement
+    }
+
     async save() {
         const { inputLeft, inputRight } = this._controls.slider.elements
         const { isSkipped } = this.read()

--- a/models/snip/current-snip.js
+++ b/models/snip/current-snip.js
@@ -48,11 +48,7 @@ export default class CurrentSnip extends Snip {
         const shareURL = `${url}?startTime=${startTime}&endTime=${endTime}`
         copyToClipBoard(shareURL)
 
-        const alertBox = document.getElementById('chorus-alert') 
-        const alertMessage = alertBox.querySelector('[id="chorus-alert-message"]')
-        alertMessage.textContent = `Snip copied to clipboard.`
-        alertBox.style.display = 'flex' 
-        setTimeout(() => { alertBox.style.display = 'none' }, 3000)
+        super._displayAlert()
     }
 
     async save() {

--- a/models/snip/snip.js
+++ b/models/snip/snip.js
@@ -44,4 +44,13 @@ export default class Snip {
     #setUpdateControls(response) {
         this._controls.updateControls(response)
     }
+
+    _displayAlert() {
+        const alertBox = document.getElementById('chorus-alert') 
+        const alertMessage = alertBox.querySelector('[id="chorus-alert-message"]')
+
+        alertMessage.textContent = `Snip copied to clipboard.`
+        alertBox.style.display = 'flex' 
+        setTimeout(() => { alertBox.style.display = 'none' }, 3000)
+    }
 }

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -48,6 +48,11 @@ export default class TrackSnip extends Snip {
         icon.style.visibility = isSnip ? 'visible' : 'hidden'
     }
 
+    share() {
+        const songInfo = trackSongInfo(this.#row)
+        console.log({ songInfo })
+    }
+
     async save() {
         const { inputLeft, inputRight } = this._controls.slider.elements
         const { isSkipped } = this.read()

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -1,6 +1,7 @@
 import Snip from './snip.js'
 
 import { trackSongInfo } from '../../utils/song.js'
+import { copyToClipBoard } from '../../utils/clipboard.js'
 
 export default class TrackSnip extends Snip {
     #row
@@ -49,8 +50,17 @@ export default class TrackSnip extends Snip {
     }
 
     share() {
-        const songInfo = trackSongInfo(this.#row)
-        console.log({ songInfo })
+        const { url } = trackSongInfo(this.#row)
+        const { startTime, endTime } = this.read()
+        
+        const shareURL = `${location.origin}${url}?startTime=${startTime}&endTime=${endTime}`
+        copyToClipBoard(shareURL)
+
+        const alertBox = document.getElementById('chorus-alert') 
+        const alertMessage = alertBox.querySelector('[id="chorus-alert-message"]')
+        alertMessage.textContent = `Snip copied to clipboard.`
+        alertBox.style.display = 'flex' 
+        setTimeout(() => { alertBox.style.display = 'none' }, 3000)
     }
 
     async save() {

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -56,11 +56,7 @@ export default class TrackSnip extends Snip {
         const shareURL = `${location.origin}${url}?startTime=${startTime}&endTime=${endTime}`
         copyToClipBoard(shareURL)
 
-        const alertBox = document.getElementById('chorus-alert') 
-        const alertMessage = alertBox.querySelector('[id="chorus-alert-message"]')
-        alertMessage.textContent = `Snip copied to clipboard.`
-        alertBox.style.display = 'flex' 
-        setTimeout(() => { alertBox.style.display = 'none' }, 3000)
+        super._displayAlert()
     }
 
     async save() {

--- a/styles.css
+++ b/styles.css
@@ -82,8 +82,8 @@
     border-color: #e5e7eb;
 }
 
-#chorus-close-button,
-#chorus-close-button:hover {
+.chorus-close-button,
+.chorus-close-button:hover {
     padding: 0;
     font-size: 1rem;
     border: none !important;

--- a/utils/clipboard.js
+++ b/utils/clipboard.js
@@ -1,0 +1,8 @@
+export const copyToClipBoard = (text) => {
+    navigator.clipboard.writeText(text)
+        .then(() => {
+            console.log(`Copied ${text} to clipboard`)
+        }).catch(err => {
+            console.error(`Error copying text to clipboard: ${err}`)
+        })
+}

--- a/utils/song.js
+++ b/utils/song.js
@@ -15,12 +15,25 @@ export const trackSongInfo = row => {
     if (!songLength) return
 
     const artists = getArtists(row)
+    const trackInfo = getTrackId(row)
 
     return {
         id:  `${song} by ${artists}`,
-        endTime: timeToSeconds(songLength)
+        endTime: timeToSeconds(songLength),
+        ...trackInfo && {...trackInfo }
     }
 }    
+
+const getTrackId = row => {
+    const trackIdUrl = row.querySelector('a[data-testid="internal-track-link"]')?.href
+    if (!trackIdUrl) return
+
+    const url = trackIdUrl.split('.com').at(1)
+    return {
+        url,
+        trackId: url.split('/').at(2)
+    }
+}
 
 const getArtists = row => {
     const artistsList = row.querySelectorAll('span > a')

--- a/utils/song.js
+++ b/utils/song.js
@@ -1,10 +1,24 @@
 import { timeToSeconds } from './time.js'
 
-export const currentSongId = () => {
-    const songName = document.querySelector('[data-testid="now-playing-widget"]')?.ariaLabel
+export const currentSongInfo = () => {
+    const songLabel = document.querySelector('[data-testid="now-playing-widget"]')?.ariaLabel
+    const trackURL = document.querySelector('[data-testid="CoverSlotCollapsed__container"] > div > a')?.href
 
     // Remove 'Now playing: ' prefix
-    return songName?.split(': ')?.at(1)
+    const id = songLabel.split(': ').at(1)
+
+    if (!trackURL) return { id }
+
+    const params = new URLSearchParams(trackURL)
+
+    const trackId = params.get('uri').split('track:').at(1)
+
+    return  {
+        id,
+        trackId, 
+        url: `${location.origin}/track/${trackId}`
+    }
+
 }
 
 export const trackSongInfo = row => {

--- a/utils/song.js
+++ b/utils/song.js
@@ -18,6 +18,7 @@ export const trackSongInfo = row => {
     const trackInfo = getTrackId(row)
 
     return {
+        startTime: 0,
         id:  `${song} by ${artists}`,
         endTime: timeToSeconds(songLength),
         ...trackInfo && {...trackInfo }


### PR DESCRIPTION
This PR allows snips to be shared (theoretically). On new `share` button press, a shareable link will be added to a user's clipboard. The link will resemble a track link with addition of `endTime` and `startTime` search query params:
https://open.spotify.com/track/4S4QJfBGGrC8jRIjJHf1Ka?startTime=28&endTime=98


![image](https://github.com/cdrani/chorus/assets/18746599/0cc88c26-e032-49e8-baaf-ac3fae86cbfa)

On opening the link, the track should start playing at the `startTime` and go to the next song at the `endTime`. Even if the user opening the link has a their own snip set on the track, the values in the url will take precedence. 

At track `endTime` reached, then the search query params will be removed the from the url, to prevent the `endTime` and `startTime` values being applied to non-shared tracks.


closes #10 