### PR TITLE
Fix: Snip & Skip Triggers On Playlist Tracklists

### DIFF
--- a/models/track-list.js
+++ b/models/track-list.js
@@ -109,7 +109,12 @@ export default class TrackList {
     }
 
     setTrackListClickEvent() {
-        const trackLists = Array.from(document.querySelectorAll('[data-testid="track-list"]'))
+        const trackLists = Array.from(
+            document.querySelectorAll([
+                '[data-testid="track-list"]', 
+                '[data-testid="playlist-tracklist"]'
+            ])
+        )
         const containers = trackLists?.map(trackList => (
             trackList.querySelector('[data-testid="top-sentinel"] + [role="presentation"]')
         ))


### PR DESCRIPTION
Add `[data-testid="playlist-tracklist"` selector in containers query. This will now add click events for snip and skip logic on respective icon presses on the tracklist container

closes #37 