### PR TITLE
feat: display track info in modal

### DIFF
--- a/components/snip-controls.js
+++ b/components/snip-controls.js
@@ -1,11 +1,13 @@
 import { createHeader } from './header.js'
 import { createSlider } from './slider.js'
 import { createRangeLabels } from './labels.js'
+import { createTrackInfo } from './track-info.js'
 import { createActionButtons } from './buttons.js'
 
 export const createSnipControls = ({ current, duration }) => `
     <div id="chorus-snip-controls" style="display: block">
         ${createHeader()}
+        ${createTrackInfo()}
         ${createSlider({ current, duration })}
         ${createRangeLabels()}
         ${createActionButtons()}

--- a/components/track-info.js
+++ b/components/track-info.js
@@ -1,0 +1,6 @@
+export const createTrackInfo = () => `
+    <div style="display:flex;flex-direction:column;margin-top:0.5rem;">
+        <p id="track-title" style="color:#fff;font-size:14px;"></p>
+        <p id="track-artists" style="font-size:11px;color:#b3b3b3;"></p>
+    </div>
+`

--- a/models/snip/current-snip.js
+++ b/models/snip/current-snip.js
@@ -13,7 +13,14 @@ export default class CurrentSnip extends Snip {
         super.init()
 
         this._controls.init()
+        this.#displayTrackInfo()
         this._controls.setInitialValues(this.read())
+    }
+
+    #displayTrackInfo() {
+        const { id } = currentSongInfo() 
+        const [title, artists] = id.split(' by ')
+        super._setTrackInfo({ title, artists })
     }
 
     get _defaultTrack() {

--- a/models/snip/snip.js
+++ b/models/snip/snip.js
@@ -53,4 +53,12 @@ export default class Snip {
         alertBox.style.display = 'flex' 
         setTimeout(() => { alertBox.style.display = 'none' }, 3000)
     }
+
+    _setTrackInfo({ title, artists }) {
+        const titleElement = document.getElementById('track-title')
+        const artistsElement = document.getElementById('track-artists')
+
+        titleElement.textContent = title
+        artistsElement.textContent = artists
+    }
 }

--- a/models/snip/track-snip.js
+++ b/models/snip/track-snip.js
@@ -15,8 +15,15 @@ export default class TrackSnip extends Snip {
 
         this.#row = row
         this._controls.init()
+        this.#displayTrackInfo()
         const { id, endTime: duration } = trackSongInfo(row)
         this._controls.setInitialValues({ ...this.read(), id, duration })
+    }
+
+    #displayTrackInfo() {
+        const { id } = trackSongInfo(this.#row) 
+        const [title, artists] = id.split(' by ')
+        super._setTrackInfo({ title, artists })
     }
 
     get _defaultTrack() {


### PR DESCRIPTION
Display track info (track name and artists) in modal.

<img width="418" alt="image" src="https://github.com/cdrani/chorus/assets/18746599/29e81335-6cc0-4aec-85c9-08497a80ba49">

closes #58 


