### PR TITLE
fix: remove currently unneeded tracklist snip icon

### DIFF
--- a/models/track-list.js
+++ b/models/track-list.js
@@ -22,7 +22,9 @@ export default class TrackList {
         this.#snipIcon = new SnipIcon(store)
         this.#trackSnip = new TrackSnip(store)
         
-        this.#icons = [this.#skipIcon, this.#snipIcon]
+        this.#icons = [
+            this.#skipIcon //, this.#snipIcon
+        ]
     }
 
     get #trackRows() {


### PR DESCRIPTION
Will be brought back shortly when ready.

closes #71 