### PR TITLE
fix: remove item from storage when no longer useful

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -46,8 +46,7 @@ window.addEventListener('message', async (event) => {
             break
 
         case 'storage.delete':
-            response = await removeState(payload.key)
-            sendEventToPage({ eventType: 'storage.delete.response', detail: response })
+            await removeState(payload.key)
             break
 
         case 'storage.populate':


### PR DESCRIPTION
Just maintenance to keep `chrome.storage.local` in sync. Any track that now has `isSkipped: false` and `isSnip: false` and `playBackRate: 1` is no longer required in storage as it's a normal Spotify track without chorus effects.