### PR TITLE
feat: new speed input step + manual inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chorus",
   "private": true,
   "type": "module",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w"

--- a/src/components/speed/speed-range.js
+++ b/src/components/speed/speed-range.js
@@ -8,7 +8,7 @@ export const createSpeedRange = () => `
             <input
                 min="0.1"
                 max="4"
-                step="0.05"
+                step="0.001"
                 type="range"
                 class="input"
                 id="speed-input"

--- a/src/components/speed/speed-toggler.js
+++ b/src/components/speed/speed-toggler.js
@@ -1,17 +1,17 @@
 import { createToggleButton } from '../toggle-button.js'
 
-const createTag = ({ tag, id, text, style = '' }) => `
-    <div style="display:flex;align-items:center;${style}">
-        <span class="chorus-text chorus-pill">${tag}</span>
-        <span class="chorus-text" id="${id}" style="height:100%;margin-left:4px;padding:0 4px">${text}</span>
+const createTag = ({ tag, id, style = '' }) => `
+    <div style="display:flex;align-items:center;${style};">
+        <span class="chorus-text chorus-pill" style="text-align:left;width:46px;padding-left:4px">${tag}</span>
+        <input id="${id}" class="chorus-text" style="color:#fff;width:42px;height:100%;padding:0 4px">
     </div>
 `
 
 export const createSpeedToggler = () => `
-    <div style="display:flex;justify-content:space-between;align-items:center;width:100%">
+    <div style="display:flex;justify-content:space-between;align-items:center;width:100%;">
         <div style="display:flex;flex-direction:column;justify-content:space-between;">
-            ${createTag({ tag: 'T', id: 'speed-track-value', text: '1x', style: 'margin-bottom:4px' })}
-            ${createTag({ tag: 'G', id: 'speed-global-value', text: '1x' })}
+            ${createTag({ tag: 'Track', id: 'speed-track-value', style: 'margin-bottom:4px' })}
+            ${createTag({ tag: 'Global', id: 'speed-global-value' })}
         </div>
 
         <div style="display:flex;flex-direction:column;justify-content:space-between;align-items:flex-end">

--- a/src/data/song-state.js
+++ b/src/data/song-state.js
@@ -14,7 +14,7 @@ const sharedSnipValues = () => {
         endTime: parseInt(endTime, 10),
         startTime: parseInt(startTime, 10),
         preservesPitch: parseInt(preservesPitch, 10) == 1,
-        playbackRate: parseFloat(playbackRate) / 100,
+        playbackRate: parseFloat(playbackRate) / 1000,
     }
 }
 

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/models/snip/snip.js
+++ b/src/models/snip/snip.js
@@ -54,7 +54,7 @@ export default class Snip {
     async _share() {
         const { startTime, endTime, playbackRate = '1.00', preservesPitch = true } = await this.read()
         const pitch = preservesPitch ? 1 : 0
-        const rate = parseFloat(playbackRate) * 100
+        const rate = parseFloat(playbackRate) * 1000
 
         const { tempEndTime = startTime, tempStartTime = endTime } = this.tempShareTimes
         

--- a/src/styles.css
+++ b/src/styles.css
@@ -247,6 +247,7 @@ input[type=number]::-webkit-outer-spin-button {
     width: 12px;
     height: 12px;
     border-radius: 50%;
+    cursor: grab;
 }
 
 .input[type="range"]::-webkit-slider-thumb {
@@ -255,6 +256,7 @@ input[type=number]::-webkit-outer-spin-button {
     width: 12px;
     height: 12px;
     border-radius: 50%;
+    cursor: grab;
 }
 
 .slider>.thumb.hover {

--- a/src/utils/higlight.js
+++ b/src/utils/higlight.js
@@ -4,7 +4,7 @@ const isHighlightable = ({
     playbackRate = '1',
     preservesPitch = true,
 }) => (
-    isSnip || isSkipped || !preservesPitch || playbackRate !== '1'
+    isSnip || isSkipped || !preservesPitch || !['1', '1.000', '1000'].includes(playbackRate)
 )
 
 export const highlightElement = ({ 

--- a/src/utils/song.js
+++ b/src/utils/song.js
@@ -62,7 +62,9 @@ const getTrackId = row => {
 const getArtists = row => {
     const artistsList = row.querySelectorAll('span > div > a')
     // Here means we are at artist page and can get name from h1
-    if (!artistsList.length) return document.querySelector('span[data-testid="entityTitle"] > h1').textContent
+    if (!artistsList.length) {
+        return document.querySelector('span[data-testid="entityTitle"] > h1')?.textContent || ''
+    }
 
     return Array.from(artistsList).filter(artist => artist.href.includes('artist')).map(artist => artist.textContent).join(', ')
 }


### PR DESCRIPTION
### Changes

<img width="448" alt="image" src="https://github.com/cdrani/chorus/assets/18746599/cc4604cc-5354-463b-af28-2e29130d753f">

- Step for Slider updated to 0.001 for finer control, though this now comes with a slight delay of 50ms so the speed is not updated too often when user is just sliding around back and forth. Without the delay, Spotify occasionally will sputter and show an alert about loading the song from a local file.
- Replace the static Track & Global Speed Indicator (originally span) to an input for user manual input of speed values such as **0.982**.
- Update the conversion factor (from 100 to 1000) for the speed value used in the share url. For EX: https://open.spotify.com/track/2w4yylkuKugYjEVhwKc0OD?ch=10-60-982-1, 982 would be the speed of **0.982**.

closes #189 