### PR TITLE
feat: better snip + loop controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chorus",
   "private": true,
   "type": "module",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w"

--- a/src/background.js
+++ b/src/background.js
@@ -19,11 +19,9 @@ async function getUIState({ selector, tabId }) {
 }
 
 async function getMediaControlsState(tabId) {
-    const requiredKeys = ['repeat', 'shuffle', 'play/pause', 'save/unsave', 'seek-rewind', 'seek-fastforward']
+    const requiredKeys = ['save/unsave', 'repeat', 'shuffle', 'play/pause', 'loop', 'seek-rewind', 'seek-fastforward',]
     const selectorKeys = { ...mediaKeys, ...chorusKeys }
-    const selectors = Object.keys(selectorKeys).map(key => (
-        requiredKeys.includes(key) ? selectorKeys[key] : undefined
-    )).filter(Boolean)
+    const selectors = requiredKeys.map(key => selectorKeys[key] ?? undefined).filter(Boolean)
 
     const promises = selectors.map(selector => (
         new Promise(resolve => {

--- a/src/background.js
+++ b/src/background.js
@@ -19,13 +19,13 @@ async function getUIState({ selector, tabId }) {
 }
 
 async function getMediaControlsState(tabId) {
-    const requiredKeys = ['save/unsave', 'repeat', 'shuffle', 'play/pause', 'loop', 'seek-rewind', 'seek-fastforward',]
+    const requiredKeys = ['repeat', 'shuffle', 'play/pause', 'seek-rewind', 'seek-fastforward', 'loop',  'save/unsave']
     const selectorKeys = { ...mediaKeys, ...chorusKeys }
     const selectors = requiredKeys.map(key => selectorKeys[key] ?? undefined).filter(Boolean)
 
     const promises = selectors.map(selector => (
         new Promise(resolve => {
-            if (!selector.includes('add-button')) return resolve(getUIState({ selector, tabId }))
+            if (!selector.includes('loop')) return resolve(getUIState({ selector, tabId }))
             return setTimeout(() => resolve(getUIState({ selector, tabId })), 500)
         })
     ))

--- a/src/components/artist-disco.js
+++ b/src/components/artist-disco.js
@@ -8,7 +8,7 @@ const dispatcher = new Dispatcher()
 const createArtistDiscoUI = () => `
     <div 
         id="artist-disco"
-        style="display:flex;width:3.5rem;height:3.5rem;align-items:center;justify-content:center"
+        style="display:flex;align-items:center;"
     >
         <button 
             role="artist-disco"

--- a/src/components/effects/effects-controls.js
+++ b/src/components/effects/effects-controls.js
@@ -4,7 +4,7 @@ import { convolverPresets, drinkPresets } from '../../lib/reverb/presets.js'
 
 export const createEffectsControls = () => `
     <div id="chorus-fx-controls" style="display: none">
-        <div style="display:flex;flex-direction:column;justify-content:space-evenly;height:6rem;">
+        <div style="display:flex;flex-direction:column;justify-content:space-between;height:5.5rem;">
             ${createEffectsSelector({ name: 'drink-effect', labelName: 'cup-sized reverb', optionNames: drinkPresets })}
             ${createEffectsSelector({ name: 'convolver-effect', labelName: 'impulse reverb', optionNames: convolverPresets })}
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -14,7 +14,7 @@ export const createHeader = () => `
     <div class="chorus-common">
         <span class="chorus-header">chorus</span>
         <div style="display:flex;justify-content:space-between;align-items:center;">
-            <div style="display:flex;height:25px;align-items:center;justify-content:space-around;">
+            <div id="header-buttons" style="display:flex;height:25px;align-items:center;justify-content:space-around;">
                 ${createHeaderButton({ role: 'snip', ariaLabel: 'Snip Controls', additionalStyles: 'background-color:green;' })}
                 ${createHeaderButton({ role: 'speed', ariaLabel: 'Speed Controls', additionalStyles: 'margin-left:.5rem;' })}
                 ${createHeaderButton({ role: 'fx', ariaLabel: 'FX Controls', additionalStyles: 'margin-left:.5rem;' })}

--- a/src/components/snip/snip-controls.js
+++ b/src/components/snip/snip-controls.js
@@ -11,7 +11,10 @@ export const createSnipControls = () => {
 
     return `
         <div id="chorus-snip-controls" style="display: block">
-            ${createSlider({ current, duration })}
+            ${createSlider({ current, duration, style: "margin:6px 0" })}
+            <p style="font-size:.75rem;color:#fff;padding:0;margin-top:-8px;padding-bottom:.5rem">
+                *while editing 'end', track plays 3 secs past set 'end'
+            </p>
             <div style="display:flex;justify-content:space-between;height:3rem;">
                 ${createRangeLabels()}
                 ${createSnipToggler()}

--- a/src/components/snip/snip-controls.js
+++ b/src/components/snip/snip-controls.js
@@ -5,21 +5,16 @@ import { createSnipButtons } from './snip-buttons.js'
 
 import { playback } from '../../utils/playback.js'
 
-export const createSnipControls = () => {
-    const current = playback.current()
-    const duration = playback.duration()
-
-    return `
-        <div id="chorus-snip-controls" style="display: block">
-            ${createSlider({ current, duration, style: "margin:6px 0" })}
-            <p style="font-size:.75rem;color:#fff;padding:0;margin-top:-8px;padding-bottom:.5rem">
-                *while editing 'end', track plays 3 secs past set 'end'
-            </p>
-            <div style="display:flex;justify-content:space-between;height:3rem;">
-                ${createRangeLabels()}
-                ${createSnipToggler()}
-            </div>
-            ${createSnipButtons()}
+export const createSnipControls = () => `
+    <div id="chorus-snip-controls" style="display: block">
+        ${createSlider({ current: playback.current(), duration: playback.duration(), style: "margin:6px 0" })}
+        <p style="font-size:.75rem;color:#fff;padding:0;margin-top:-8px;padding-bottom:.5rem">
+            * while editing 'end', track plays 3 secs past set 'end'
+        </p>
+        <div style="display:flex;justify-content:space-between;height:3rem;">
+            ${createRangeLabels()}
+            ${createSnipToggler()}
         </div>
-    `
-}
+        ${createSnipButtons()}
+    </div>
+`

--- a/src/components/snip/snip-controls.js
+++ b/src/components/snip/snip-controls.js
@@ -1,5 +1,6 @@
 import { createSlider } from './snip-slider.js'
 import { createRangeLabels } from './snip-labels.js'
+import { createSnipToggler } from './snip-toggle.js'
 import { createSnipButtons } from './snip-buttons.js'
 
 import { playback } from '../../utils/playback.js'
@@ -11,7 +12,10 @@ export const createSnipControls = () => {
     return `
         <div id="chorus-snip-controls" style="display: block">
             ${createSlider({ current, duration })}
-            ${createRangeLabels()}
+            <div style="display:flex;justify-content:space-between;height:3rem;">
+                ${createRangeLabels()}
+                ${createSnipToggler()}
+            </div>
             ${createSnipButtons()}
         </div>
     `

--- a/src/components/snip/snip-labels.js
+++ b/src/components/snip/snip-labels.js
@@ -9,7 +9,7 @@ const createLabel = text => `
 `
 
 export const createRangeLabels = () => `
-    <div style="display:flex;justify-content:space-between;height:3rem;align-items:center;">
+    <div style="display:flex;flex-direction:column;justify-content:space-between;">
         ${createLabel('start')}
         ${createLabel('end')}
     </div>

--- a/src/components/snip/snip-labels.js
+++ b/src/components/snip/snip-labels.js
@@ -1,9 +1,9 @@
-const style = "min-width:24px;font-size:0.85rem;text-align:end;margin-left:4px"
+const style = 'width:90px;font-size:0.85rem;margin-left:8px;text-align:center;background:green;color:#fff;'
 
 const createLabel = text => `
     <div>
-        <label class="chorus-common" style="width:100%;align-items: end">
-            ${text}: <span style="${style}" id="chorus-${text}"></span>
+        <label class="chorus-common" style="width:100%;align-items:end">
+            ${text}: <input style="${style}" id="chorus-${text}"/>
         </label>
     </div>
 `

--- a/src/components/snip/snip-labels.js
+++ b/src/components/snip/snip-labels.js
@@ -1,15 +1,21 @@
-const style = 'width:90px;font-size:0.85rem;margin-left:8px;text-align:center;background:green;color:#fff;'
+const style = 'border:none;width:82px;font-size:0.75rem;margin-left:8px;text-align:center;background:green;color:#fff;'
 
 const createLabel = text => `
-    <div>
-        <label class="chorus-common" style="width:100%;align-items:end">
-            ${text}: <input style="${style}" id="chorus-${text}"/>
-        </label>
+    <div class="chorus-common" style="display:flex;align-items:center;height:22px;">
+        <span class="chorus-text chorus-pill" style="font-size:1rem;line-height:22px;height:100%;text-align:center;width:56px;padding:0 4px">
+            ${text}
+        </span>
+        <input id="chorus-${text}" class="chorus-text" style="padding:0 6px;width:100%;text-align:end;background:green;border:none;color:#fff;height:100%;">
     </div>
 `
 
+    // <div>
+    //     <label class="chorus-common" style="width:100%;align-items:end;height:22px;">
+    //         ${text}: <input class="chorus-text" style="height:100%;${style}" id="chorus-${text}"/>
+    //     </label>
+    // </div>
 export const createRangeLabels = () => `
-    <div style="display:flex;flex-direction:column;justify-content:space-between;">
+    <div style="display:flex;flex-direction:column;justify-content:space-between;width:100%">
         ${createLabel('start')}
         ${createLabel('end')}
     </div>

--- a/src/components/snip/snip-labels.js
+++ b/src/components/snip/snip-labels.js
@@ -1,19 +1,12 @@
-const style = 'border:none;width:82px;font-size:0.75rem;margin-left:8px;text-align:center;background:green;color:#fff;'
-
 const createLabel = text => `
     <div class="chorus-common" style="display:flex;align-items:center;height:22px;">
-        <span class="chorus-text chorus-pill" style="font-size:1rem;line-height:22px;height:100%;text-align:center;width:56px;padding:0 4px">
+        <span class="chorus-text chorus-pill" style="font-size:1rem;line-height:22px;height:100%;text-align:center;min-width:43px;width:56px;padding:0 4px">
             ${text}
         </span>
-        <input id="chorus-${text}" class="chorus-text" style="padding:0 6px;width:100%;text-align:end;background:green;border:none;color:#fff;height:100%;">
+        <input id="chorus-${text}" class="chorus-text" style="letter-spacing:0.5px;padding:0 4px;width:100%;text-align:end;background:green;border:none;color:#fff;height:100%;">
     </div>
 `
 
-    // <div>
-    //     <label class="chorus-common" style="width:100%;align-items:end;height:22px;">
-    //         ${text}: <input class="chorus-text" style="height:100%;${style}" id="chorus-${text}"/>
-    //     </label>
-    // </div>
 export const createRangeLabels = () => `
     <div style="display:flex;flex-direction:column;justify-content:space-between;width:100%">
         ${createLabel('start')}

--- a/src/components/snip/snip-slider.js
+++ b/src/components/snip/snip-slider.js
@@ -8,8 +8,8 @@ const createTime = ({ id, time }) => `
     <p class="time${id == 'end' ? ' end' : ''}"><span id="${id}">${time}</span></p>
 `
 
-export const createSlider = ({ current, duration }) => `
-    <div id="snippy" class="snippy">
+export const createSlider = ({ current, duration, style = '' }) => `
+    <div id="snippy" class="snippy" style="${style}">
         ${createTime({ id: 'start', time: '0:00' })}
         <div class="slider-container">
             ${createInput({ type: 'start', max: duration, value: current })}

--- a/src/components/snip/snip-slider.js
+++ b/src/components/snip/snip-slider.js
@@ -1,7 +1,7 @@
 import { secondsToTime } from '../../utils/time.js'
 
 const createInput = ({ type, max, value }) =>  `
-    <input min="0" max="${max}" type="range" class="input" value="${value}" id="input-${type}">
+    <input min="0" max="${max}" step="0.01" type="range" class="input" value="${value}" id="input-${type}">
 `
 
 const createTime = ({ id, time }) => `

--- a/src/components/snip/snip-toggle.js
+++ b/src/components/snip/snip-toggle.js
@@ -1,0 +1,16 @@
+import { createToggleButton } from '../toggle-button.js'
+
+export const createSnipToggler = () => `
+    <div style="display:flex;justify-content:flex-end;align-items:center;width:100%;">
+        <div style="display:flex;justify-content:space-between;align-items:flex-end">
+            ${createToggleButton({ 
+                labelId: 'loop-label',
+                labelText: 'Auto-Loop',
+                onPathId: 'loop-toggle-on',
+                offPathId: 'loop-toggle-off',
+                checkboxId: 'loop-checkbox',
+                buttonId: 'loop-toggle-button',
+            })}
+        </div>
+    </div>
+`

--- a/src/components/speed/speed-toggler.js
+++ b/src/components/speed/speed-toggler.js
@@ -3,7 +3,7 @@ import { createToggleButton } from '../toggle-button.js'
 const createTag = ({ tag, id, style = '' }) => `
     <div style="display:flex;align-items:center;height:22px;${style};">
         <span class="chorus-text chorus-pill" style="line-height:22px;height:100%;font-size:14px;text-align:center;width:56px;padding:0 4px">${tag}</span>
-        <input id="${id}" class="chorus-text" style="border:none;color:#fff;width:48px;height:100%;padding:0 4px">
+        <input id="${id}" class="chorus-text" style="letter-spacing:0.5px;border:none;color:#fff;width:48px;height:100%;padding:0 4px">
     </div>
 `
 

--- a/src/components/speed/speed-toggler.js
+++ b/src/components/speed/speed-toggler.js
@@ -3,7 +3,7 @@ import { createToggleButton } from '../toggle-button.js'
 const createTag = ({ tag, id, style = '' }) => `
     <div style="display:flex;align-items:center;height:22px;${style};">
         <span class="chorus-text chorus-pill" style="line-height:22px;height:100%;font-size:14px;text-align:center;width:56px;padding:0 4px">${tag}</span>
-        <input id="${id}" class="chorus-text" style="letter-spacing:0.5px;border:none;color:#fff;width:48px;height:100%;padding:0 4px">
+        <input id="${id}" class="chorus-text" style="text-align:end;letter-spacing:0.5px;border:none;color:#fff;width:56px;height:100%;padding:0 4px">
     </div>
 `
 

--- a/src/components/speed/speed-toggler.js
+++ b/src/components/speed/speed-toggler.js
@@ -1,15 +1,15 @@
 import { createToggleButton } from '../toggle-button.js'
 
 const createTag = ({ tag, id, style = '' }) => `
-    <div style="display:flex;align-items:center;${style};">
-        <span class="chorus-text chorus-pill" style="text-align:left;width:46px;padding-left:4px">${tag}</span>
-        <input id="${id}" class="chorus-text" style="color:#fff;width:42px;height:100%;padding:0 4px">
+    <div style="display:flex;align-items:center;height:22px;${style};">
+        <span class="chorus-text chorus-pill" style="line-height:22px;height:100%;font-size:14px;text-align:center;width:56px;padding:0 4px">${tag}</span>
+        <input id="${id}" class="chorus-text" style="border:none;color:#fff;width:48px;height:100%;padding:0 4px">
     </div>
 `
 
 export const createSpeedToggler = () => `
-    <div style="display:flex;justify-content:space-between;align-items:center;width:100%;">
-        <div style="display:flex;flex-direction:column;justify-content:space-between;">
+    <div style="display:flex;justify-content:space-between;width:100%;height:3.5rem;">
+        <div style="display:flex;flex-direction:column;justify-content:space-between;height:100%">
             ${createTag({ tag: 'Track', id: 'speed-track-value', style: 'margin-bottom:4px' })}
             ${createTag({ tag: 'Global', id: 'speed-global-value' })}
         </div>

--- a/src/components/text-button.js
+++ b/src/components/text-button.js
@@ -6,7 +6,7 @@ export const createTextButton = ({ id, text, style }) => {
         <button
             id="chorus-${id}-button"
             class="chorus-text-button ${btnTypeClass ?? ''}"
-            style="padding:0 10px;height:100%;font-size:1rem;${style || ''}"
+            style="display:flex;justify-content:center;align-items:center;padding:0 10px;height:100%;font-size:1rem;${style || ''}"
         >
             <span>${text}</span>
         </button>

--- a/src/components/toggle-button.js
+++ b/src/components/toggle-button.js
@@ -13,7 +13,7 @@ export const createToggleButton = ({
         style="z-index:100;padding:0;background-color:transparent;display:flex;align-items:center;user-select:none;"
     >
         ${labelId && labelText && `
-            <span id="${labelId}" style="font-size:1rem;color:#fff;margin-right:1rem">${labelText}</span>
+            <span id="${labelId}" style="font-weight:600;font-size:1rem;color:#fff;margin-right:1rem">${labelText}</span>
         `}
 
         <input 

--- a/src/components/track-info.js
+++ b/src/components/track-info.js
@@ -1,5 +1,5 @@
 export const createTrackInfo = () => `
-    <div style="display:flex;flex-direction:column;width:100%;justify-content:space-evenly;margin-top:.5rem">
+    <div style="display:flex;flex-direction:column;width:100%;justify-content:space-evenly;margin:.5rem 0">
         <div class="container" style="width:282px"><div class="track-text" id="track-title"></div></div>
         <div class="container" style="width:282px"><div class="track-text" id="track-artists"></div></div>
     </div>

--- a/src/data/current.js
+++ b/src/data/current.js
@@ -68,7 +68,7 @@ class CurrentData {
     }
 
     async readTrack() {
-        return await this._store.getTrack({ id: currentSongInfo().id, value: this.#trackDefaults })
+        return await this._store.getTrack({ id: currentSongInfo().id, value: { ...this.#trackDefaults, ...currentSongInfo() }})
     }
 
     async readGlobals() {

--- a/src/data/current.js
+++ b/src/data/current.js
@@ -28,6 +28,7 @@ class CurrentData {
             ...currentSongInfo(),
             startTime: 0,
             isSnip: false,
+            autoLoop: false,
             isSkipped: false,
             endTime: playback.duration()
         }

--- a/src/events/listeners/header-listeners.js
+++ b/src/events/listeners/header-listeners.js
@@ -1,4 +1,5 @@
 import Listeners from './listeners.js'
+import { spotifyVideo } from '../../actions/overload.js'
 
 export default class HeaderListeners extends Listeners {
     constructor(songTracker) {
@@ -6,6 +7,7 @@ export default class HeaderListeners extends Listeners {
 
         this._setup = false
         this._viewInFocus = null
+        this._video = spotifyVideo.element
         this._VIEWS = ['snip', 'speed', 'fx', 'seek']
     }
 
@@ -18,7 +20,7 @@ export default class HeaderListeners extends Listeners {
         this.#effectsViewToggle()
         this.#closeModalListener()
 
-        this._currentView = 'snip'
+        this.currentView = 'snip'
         this._setup = true
     }
 
@@ -30,13 +32,15 @@ export default class HeaderListeners extends Listeners {
     #seekViewToggle() {
         const seekButton = document.getElementById('chorus-seek-button')
         seekButton?.addEventListener('click', async () => {
-            this._currentView = 'seek'
+            this.currentView = 'seek'
             await this._seek.init()
         })
     }
 
-    set _currentView(selectedView) {
+    set currentView(selectedView = 'snip') {
         this._viewInFocus = selectedView
+        if (selectedView != 'snip') this._video.resetTempTimes()
+
         this._VIEWS.forEach(view => {
             const viewButton = document.getElementById(`chorus-${view}-button`)
             const viewInFocusContainer = document.getElementById(`chorus-${view}-controls`)
@@ -49,13 +53,16 @@ export default class HeaderListeners extends Listeners {
 
     #snipViewToggle() {
         const snipButton = document.getElementById('chorus-snip-button')
-        snipButton?.addEventListener('click', () => { this._currentView = 'snip' })
+        snipButton?.addEventListener('click', async () => { 
+              this.currentView = 'snip'
+              await this._snip.init()
+        })
     }
 
     #speedViewToggle() {
         const speedButton = document.getElementById('chorus-speed-button')
         speedButton?.addEventListener('click', async () => {
-            this._currentView = 'speed'
+            this.currentView = 'speed'
             await this._speed.init()
         })
     }
@@ -63,7 +70,7 @@ export default class HeaderListeners extends Listeners {
     #effectsViewToggle() {
         const effectsButton = document.getElementById('chorus-fx-button')
         effectsButton?.addEventListener('click', () => {
-            this._currentView = 'fx'
+            this.currentView = 'fx'
             this._reverb.init()
         })
     }

--- a/src/events/listeners/listeners.js
+++ b/src/events/listeners/listeners.js
@@ -16,6 +16,6 @@ export default class Listeners {
     _hide() {
         const mainElement = document.getElementById('chorus-main')
         mainElement.style.display = 'none'
-        this._video.isEditing = false
+        this._video.resetTempTimes()
     }
 }

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -49,6 +49,9 @@
     "on/off": {
       "description": "Toggle Extension On/Off"
     },
+    "loop": {
+      "description": "Loop/UnLoop Snip/Track"
+    },
     "next": {
       "description": "Next Track"
     },

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -49,6 +49,9 @@
     "on/off": {
       "description": "Toggle Extension On/Off"
     },
+    "loop": {
+      "description": "Loop/UnLoop Snip/Track"
+    },
     "next": {
       "description": "Next Track"
     },

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/models/chorus.js
+++ b/src/models/chorus.js
@@ -26,21 +26,13 @@ export default class Chorus {
         return this.mainElement.style.display == 'block'
     }
 
-    get mainElement() {
-        return document.getElementById('chorus-main')
-    }
+    get mainElement() { return document.getElementById('chorus-main') }
 
-    get chorusControls() {
-        return document.getElementById('chorus-controls')
-    }
+    get chorusControls() { return document.getElementById('chorus-controls') }
 
-    toggle() {
-        this.isShowing ? this.hide() : this.show()
-    }
+    toggle() { this.isShowing ? this.hide() : this.show() }
 
-    get #hasSnipControls() {
-        return !!document.getElementById('chorus-snip-controls')
-    }
+    get #hasSnipControls() { return !!document.getElementById('chorus-snip-controls') }
 
     #insertIntoDOM() {
         if (this.#hasSnipControls) return
@@ -60,15 +52,14 @@ export default class Chorus {
         if (!this.mainElement) return
         
         await this.headerListeners.hide()
-        this._video.isEditing = false
         this.mainElement.style.display = 'none'
+        this._video.resetTempTimes() 
     }
 
     show() {
         this.#insertIntoDOM()
         this.mainElement.style.display = 'block'
 
-        this._video.isEditing = true
         this.headerListeners.init()
         this.actionListeners.init()
     }

--- a/src/models/loop-icon.js
+++ b/src/models/loop-icon.js
@@ -1,0 +1,81 @@
+import { store } from '../stores/data.js'
+import { currentData } from '../data/current.js'
+import { parseNodeString } from '../utils/parser.js'
+import { highlightLoopIcon } from '../utils/higlight.js'
+
+export default class LoopIcon {
+    constructor(songTracker) { this._songTracker = songTracker }
+
+    init() { this.#placeIcon(); this.#setupListeners() }
+
+    get #autoLoopUI() {
+        return `
+            <button
+                role="loop"
+                id="loop-button"
+                aria-label"Loop Snip"
+                class="chorus-hover-white"
+                style="display:none;justify-content:center;align-items:center;border:none;background:none;"
+            >
+                <svg 
+                    role="loop"
+                    height="1.25rem"
+                    width="1.25rem"
+                    id="loop-icon"
+                    fill="currentColor"
+                    stroke="currentColor"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                    preserveAspectRatio="xMidYMid meet"
+                >
+                    <g id="loop-group" fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="48">
+                        <path d="m256 256s-48-96-126-96c-54.12 0-98 43-98 96s43.88 96 98 96c30 0 56.45-13.18 78-32"/>
+                        <path d="m256 256s48 96 126 96c54.12 0 98-43 98-96s-43.88-96-98-96c-29.37 0-56.66 13.75-78 32"/>
+                    </g>
+                </svg>
+            </button>
+        `
+    }
+
+    get #loopButton() { return document.getElementById('loop-button') }
+
+    #placeIcon() {
+        if (this.#loopButton) return (this.#loopButton.style.display = 'flex')
+
+        const skipForwardButton = document.querySelector('[data-testid="control-button-skip-forward"]')
+        const loopButton = parseNodeString(this.#autoLoopUI)
+        skipForwardButton?.parentElement?.appendChild(loopButton)
+    }
+
+    updateIconPosition() {
+        const skipForwardButton = document.querySelector('[data-testid="control-button-skip-forward"]')
+        const parentElement = skipForwardButton?.parentElement
+        parentElement?.insertBefore(this.#loopButton, parentElement.lastElementChild.nextSibling)
+    }
+
+    get #isHiglighted() {
+        const group =  document.getElementById('auto-group')
+        if (!group) return false
+
+        return group.style.stroke == '#1ed760'
+    }
+    
+    highlightIcon({ isSnip, autoLoop = false }) { 
+        this.#loopButton.style.display = isSnip ? 'flex' : 'none'
+        if (isSnip || (!isSnip && this.#isHiglighted)) highlightLoopIcon(autoLoop) 
+    }
+
+    removeIcon() { this.#loopButton?.remove() }
+
+    async #handleLoopButton() {
+        const track = await currentData.readTrack()
+        const autoLoop = !track?.autoLoop ?? false
+        this.highlightIcon({ isSnip: track.isSnip, autoLoop })
+
+        const updatedTrack = await store.saveTrack({ id: track.id, value: { ...track, autoLoop }})
+        await this._songTracker.updateCurrentSongData(updatedTrack)
+    }
+
+    #setupListeners() { this.#loopButton.onclick = () => this.#handleLoopButton() }
+}
+

--- a/src/models/loop-icon.js
+++ b/src/models/loop-icon.js
@@ -13,7 +13,7 @@ export default class LoopIcon {
             <button
                 role="loop"
                 id="loop-button"
-                aria-label"Loop Snip"
+                aria-label="Loop Snip"
                 class="chorus-hover-white"
                 style="display:none;justify-content:center;align-items:center;border:none;background:none;"
             >
@@ -62,6 +62,7 @@ export default class LoopIcon {
     
     highlightIcon({ isSnip, autoLoop = false }) { 
         this.#loopButton.style.display = isSnip ? 'flex' : 'none'
+        this.#loopButton.setAttribute('aria-label', autoLoop ? 'Remove Loop' : 'Loop Snip' )
         if (isSnip || (!isSnip && this.#isHiglighted)) highlightLoopIcon(autoLoop) 
     }
 

--- a/src/models/loop-icon.js
+++ b/src/models/loop-icon.js
@@ -24,20 +24,17 @@ export default class LoopIcon {
                 style="display:flex;justify-content:center;align-items:center;border:none;background:none;"
             >
                 <svg 
-                    role="loop"
-                    height="1.25rem"
-                    width="1.25rem"
                     id="loop-icon"
+                    width="1.25rem"
+                    height="1.25rem"
                     fill="currentColor"
                     stroke="currentColor"
-                    viewBox="0 0 512 512"
+                    viewBox="0 0 32 32"
+                    stroke-width="0.2"
                     xmlns="http://www.w3.org/2000/svg"
                     preserveAspectRatio="xMidYMid meet"
                 >
-                    <g id="loop-group" fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="48">
-                        <path d="m256 256s-48-96-126-96c-54.12 0-98 43-98 96s43.88 96 98 96c30 0 56.45-13.18 78-32"/>
-                        <path d="m256 256s48 96 126 96c54.12 0 98-43 98-96s-43.88-96-98-96c-29.37 0-56.66 13.75-78 32"/>
-                    </g>
+                    <path xmlns="http://www.w3.org/2000/svg" d="m16 28.0063c-4.6831 0-8.49375-3.8075-8.5-8.4894-.005-.4138.02437-5.6125 4.245-9.91878.3962-.40437.8162-.78749 1.2575-1.14874-2.55-.96375-5.92312-1.44938-9.5025-1.44938-.82812 0-1.5-.67188-1.5-1.5s.67188-1.5 1.5-1.5c4.8675 0 9.2506.83875 12.5106 2.50062 3.2563-1.65375 7.6325-2.48812 12.4894-2.48812.8281 0 1.5.67188 1.5 1.5 0 .82813-.6719 1.5-1.5 1.5-3.5712 0-6.9388.48312-9.485 1.44187.4337.35563.8456.73188 1.2356 1.13 4.2219 4.30563 4.2544 9.50443 4.25 9.92003v.0025c-.0006 4.6862-3.8137 8.4994-8.5006 8.4994zm.0081-18.04255c-.7818.51185-1.4887 1.08995-2.12 1.73435-3.4331 3.5025-3.3887 7.7356-3.3881 7.7781v.0301c0 3.0325 2.4675 5.5 5.5 5.5s5.5-2.4675 5.5-5.5v-.0388c0-.1538-.0406-4.3962-3.43-7.8219-.6163-.6231-1.3037-1.1837-2.0619-1.68185z"/>
                 </svg>
             </button>
         `
@@ -58,10 +55,10 @@ export default class LoopIcon {
     }
 
     get #isHiglighted() {
-        const group =  document.getElementById('loop-group')
-        if (!group) return false
+        const svgIcon =  document.getElementById('loop-icon')
+        if (!svgIcon) return false
 
-        return group.style.stroke == '#1ed760'
+        return svgIcon.getAttribute('fill') == '#1ed760'
     }
     
     highlightIcon({ isSnip, autoLoop = false }) { 
@@ -88,6 +85,6 @@ export default class LoopIcon {
         await this._songTracker.updateCurrentSongData(updatedTrack)
     }
 
-    #setupListeners() { this.#loopButton.onclick = () => this.#handleLoopButton() }
+    #setupListeners() { this.#loopButton.onclick = async () => await this.#handleLoopButton() }
 }
 

--- a/src/models/loop-icon.js
+++ b/src/models/loop-icon.js
@@ -66,7 +66,8 @@ export default class LoopIcon {
             this._video.element.setAttribute('startTime', 0)
             this._video.element.setAttribute('endTime', playback.duration())
         }
-        if (isSnip) { this._video.resetTempTimes() }
+
+        if (!isSnip && !autoLoop) { this._video.resetTempTimes() }
 
         this.#loopButton.setAttribute('aria-label', autoLoop ? 'Remove Loop' : `Loop ${isSnip ? 'Snip' : 'Track'}` )
         highlightLoopIcon(autoLoop) 

--- a/src/models/seek/seek-icon.js
+++ b/src/models/seek/seek-icon.js
@@ -33,18 +33,13 @@ export default class SeekIcons {
         return ['track', 'album'].includes(contextType) ? 'global' : 'shows'
     }
 
-    get rwIcon() {
-        return createSeekIcon('rw')
-    }
+    get rwIcon() { return createSeekIcon('rw') }
 
-    get ffIcon() {
-        return createSeekIcon('ff')
-    }
+    get ffIcon() { return createSeekIcon('ff') }
 
     get #spotifySeekIcons() {
         const spotifyRWIcon = document.querySelector('[data-testid="control-button-seek-back-15"]')
         const spotifyFFIcon = document.querySelector('[data-testid="control-button-seek-forward-15"]')
-
         return { spotifyFFIcon, spotifyRWIcon }
     }
 

--- a/src/models/slider/slider-controls.js
+++ b/src/models/slider/slider-controls.js
@@ -1,36 +1,25 @@
 import Slider from './slider.js'
-
 import { playback } from '../../utils/playback.js'
-import { secondsToTime } from '../../utils/time.js'
+import { formatTimeInSeconds } from '../../utils/time.js'
 
 export default class SliderControls {
-    constructor() {
-        this._slider = new Slider()
-    }
+    constructor() { this._slider = new Slider() }
 
-    init() {
-        this._slider.init()
-    }
+    init() { this._slider.init() }
 
     setInitialValues(track) {
         this._slider.setInitialValues(track)
         this.#setInitialStartAndEndValues(track)
     }
 
-    get #labelElements() {
-        return {
-            labelEnd: document.getElementById('chorus-end'),
-            labelStart: document.getElementById('chorus-start'),
-        }
+    get #inputElements() {
+        return { inputStart: document.getElementById('chorus-start'), inputEnd: document.getElementById('chorus-end') }
     }
 
     #setInitialStartAndEndValues(track) {
-        const { labelStart, labelEnd } = this.#labelElements
-
-        const { startTime, endTime } = track
-
-        labelStart.textContent = secondsToTime(startTime ?? 0)
-        labelEnd.textContent = secondsToTime(endTime ?? playback.duration())
+        const { inputStart, inputEnd } = this.#inputElements
+        inputStart.value = formatTimeInSeconds(track.startTime ?? 0)
+        inputEnd.value = formatTimeInSeconds(track.endTime ?? playback.duration())
     }
 
     get #isControlsOpen() {
@@ -43,12 +32,9 @@ export default class SliderControls {
     updateControls(track) {
         if (!this.#isControlsOpen) return
 
-        const { startTime, endTime } = track
-
-        const current = playback.current()
-        const duration = playback.duration()
-
-        this._slider.updateSliderLeftHalf(startTime ?? current)
-        this._slider.updateSliderRightHalf(endTime ?? duration)
+        const startValue =  track.startTime ?? playback.current()
+        const endValue = track.endTime ?? playback.duration()
+        this._slider.updateSliderLeftHalf(startValue)
+        this._slider.updateSliderRightHalf(endValue)
     }
 }

--- a/src/models/slider/slider.js
+++ b/src/models/slider/slider.js
@@ -13,10 +13,7 @@ export default class Slider {
         this._video = spotifyVideo.element
     }
 
-    init() {
-        this.#setUpEvents()
-        this._video.element.setAttribute('lastSetThumb', '')
-    }
+    init() { this.#setUpEvents() }
 
     #setUpEvents() {
         const { inputLeft, inputRight, thumbLeft, thumbRight, outputLeft, outputRight } = this.#elements
@@ -84,26 +81,29 @@ export default class Slider {
     #setLeftValue() {
         if (this._leftDebouncer) clearTimeout(this._leftDebouncer)
 
-        const { inputLeft } = this.#elements
-        const currentValue = parseFloat(inputLeft.value)
+        const currentValue = parseFloat(this.#elements.inputLeft.value)
         this.updateSliderLeftHalf(currentValue)
-        this._video.element.setAttribute('lastSetThumb', 'start')
 
-        this._leftDebouncer = setTimeout(() => {
-            this._isCurrentlyPlaying && (this._video.currentTime = inputLeft.value)
+        this._leftDebouncer = setTimeout(() => { 
+              this.#setCurrentTimePosition({ attribute: 'startTime', position: currentValue })
         }, this._delay)
+    }
+
+    #setCurrentTimePosition({ attribute, position }) {
+        this._isCurrentlyPlaying && (this._video.currentTime = position)
+
+        this._video.element.setAttribute(attribute, position)
+        this._video.element.setAttribute('lastSetThumb', attribute.startsWith('start') ? 'start' : 'end')
     }
 
     #setRightValue() {
         if (this._rightDebouncer) clearTimeout(this._rightDebouncer)
 
-        const { inputRight } = this.#elements
-        const currentValue = parseFloat(inputRight.value)
+        const currentValue = parseFloat(this.#elements.inputRight.value)
         this.updateSliderRightHalf(currentValue)
-        this._video.element.setAttribute('lastSetThumb', 'end')
 
         this._rightDebouncer = setTimeout(() => {
-            this._isCurrentlyPlaying && (this._video.currentTime = inputRight.value)
+            this.#setCurrentTimePosition({ attribute: 'endTime', position: currentValue })
         }, this._delay)
     }
 
@@ -136,7 +136,9 @@ export default class Slider {
         updateLeft ? this.updateSliderLeftHalf(valueInSeconds) : this.updateSliderRightHalf(valueInSeconds)
 
         this.#toggleOutputOutline(updateLeft)
-        if (this._isCurrentlyPlaying) this._video.currentTime = valueInSeconds
+
+        const attribute = updateLeft ? 'startTime' : 'endTime'
+        this.#setCurrentTimePosition({ attribute, position: valueInSeconds })
     }
 
     updateSliderLeftHalf(currentValue) {

--- a/src/models/slider/slider.js
+++ b/src/models/slider/slider.js
@@ -16,11 +16,13 @@ export default class Slider {
     init() { this.#setUpEvents() }
 
     #setUpEvents() {
-        const { inputLeft, inputRight, thumbLeft, thumbRight, outputLeft, outputRight } = this.#elements
+        const { inputLeft, inputRight, loopToggleButton, thumbLeft, thumbRight, outputLeft, outputRight } = this.#elements
 
         inputLeft.oninput = () => { this.#setLeftValue(); this.#toggleOutputOutline(true) }
         inputRight.oninput = () => { this.#setRightValue(); this.#toggleOutputOutline(false) }
-    
+
+        loopToggleButton.onclick = () => this.#toggleLoopCheckbox()
+
         outputLeft.onchange = (e) => this.#handleInput(e)
         outputRight.onchange = (e) => this.#handleInput(e)
 
@@ -35,16 +37,34 @@ export default class Slider {
         inputRight.addEventListener('mouseup', () => thumbRight.classList.remove('active'))
     }
 
+    #toggleLoopCheckbox() {
+        const loopCheckBox = this.#elements.loopCheckBox
+        loopCheckBox.checked = !loopCheckBox.checked
+        this.#setCheckedUI(loopCheckBox.checked)
+    }
+
+    #setCheckedUI(loop) {
+        const { loopToggleOn, loopToggleOff } = this.#elements
+
+        loopToggleOn.style.display = loop ? 'block' : 'none'
+        loopToggleOff.style.display = loop ? 'none' : 'block'
+    }
+
     #toggleOutputOutline(outlineLeft) {
-        this.#elements.outputLeft.style.outline = outlineLeft  ? 'solid 1px #fff' : ''
-        this.#elements.outputRight.style.outline = outlineLeft  ? '' : 'solid 1px #fff'
+        const { outputLeft, outputRight } = this.#elements
+
+        outputLeft.style.outline = outlineLeft  ? 'solid 1px #fff' : ''
+        outputRight.style.outline = outlineLeft  ? '' : 'solid 1px #fff'
+
+        if (outlineLeft) { outputLeft.focus(); outputRight.blur() }
+        if (!outlineLeft) { outputLeft.blur(); outputRight.focus() }
     }
 
     setInitialValues(track) {
         this._isCurrentlyPlaying = !track?.id ? true : track.id == currentSongInfo().id
 
-        const { endTime, startTime } = track
-        const { endDisplay, outputLeft, outputRight } = this.#elements
+        const { endTime, startTime, autoLoop = false } = track
+        const { endDisplay, outputLeft, outputRight, loopCheckBox } = this.#elements
         const duration = track?.duration ?? playback.duration()
 
         endDisplay.textContent = secondsToTime(duration)
@@ -57,6 +77,9 @@ export default class Slider {
         const endValue = endTime ?? duration
         this.updateSliderRightHalf(endValue)
         outputRight.value = formatTimeInSeconds(endTime)
+
+        loopCheckBox.checked = autoLoop
+        this.#setCheckedUI(autoLoop)
     }
 
     #setMaxMin(duration) {
@@ -70,11 +93,17 @@ export default class Slider {
             endDisplay: document.getElementById('end'),
             outputRight: document.getElementById('chorus-end'),
             outputLeft: document.getElementById('chorus-start'),
+
             inputLeft: document.getElementById('input-start'),
             inputRight: document.getElementById('input-end'),
             range: document.querySelector('.slider > .range'),
             thumbLeft: document.querySelector('.slider > .thumb.left'),
             thumbRight: document.querySelector('.slider > .thumb.right'),
+
+            loopCheckBox: document.getElementById('loop-checkbox'),
+            loopToggleOn: document.getElementById('loop-toggle-on'),
+            loopToggleOff: document.getElementById('loop-toggle-off'),
+            loopToggleButton: document.getElementById('loop-toggle-button')
         }
     }
 

--- a/src/models/snip/current-snip.js
+++ b/src/models/snip/current-snip.js
@@ -4,6 +4,7 @@ import { spotifyVideo } from '../../actions/overload.js'
 
 import { playback } from '../../utils/playback.js'
 import { currentSongInfo } from '../../utils/song.js'
+import { highlightLoopIcon } from '../../utils/higlight.js'
 
 export default class CurrentSnip extends Snip {
     constructor(songTracker) {
@@ -70,6 +71,7 @@ export default class CurrentSnip extends Snip {
 
         this._video.resetTempTimes()
         this.updateView()
+        highlightLoopIcon(result?.autoLoop ?? false)
         this.skipTrackOnSave(result)
 
         await this._songTracker.updateCurrentSongData(result)

--- a/src/models/snip/current-snip.js
+++ b/src/models/snip/current-snip.js
@@ -51,7 +51,7 @@ export default class CurrentSnip extends Snip {
 
     async save() {
         const track = await this.read()
-        const { inputLeft, inputRight, title, artists } = this._elements
+        const { loopCheckBox, inputLeft, inputRight, title, artists } = this._elements
         const { id, isSkipped } = track
 
         const trackId = id ?? `${title.textContent} by ${artists.textContent}`
@@ -63,6 +63,7 @@ export default class CurrentSnip extends Snip {
                 isSnip: true,
                 startTime: inputLeft.value,
                 endTime: inputRight.value,
+                autoLoop: loopCheckBox.checked,
                 isSkipped: inputRight.value == 0 || isSkipped,
             },
         })

--- a/src/models/snip/current-snip.js
+++ b/src/models/snip/current-snip.js
@@ -28,27 +28,16 @@ export default class CurrentSnip extends Snip {
         super._setTrackInfo({ title, artists })
     }
 
-    get _defaultTrack() {
-        return currentData.readTrack()
-    }
+    get _defaultTrack() { return currentData.readTrack() }
 
-    updateView() {
-        super._updateView()
-    }
+    updateView() { super._updateView() }
 
-    get trackURL() {
-        const { url } = currentSongInfo()
-        return url
-    }
+    get trackURL() { return currentSongInfo().url }
 
-    share() {
-        super._share()
-    }
+    share() { super._share() }
 
     skipTrackOnSave({ isSkipped }) {
-        if (isSkipped) {
-            document.querySelector('[data-testid="control-button-skip-forward"]')?.click()   
-        }
+        isSkipped && document.querySelector('[data-testid="control-button-skip-forward"]')?.click()   
     }
 
     setCurrentTime({ prevEndTime, endTime }) {

--- a/src/models/snip/current-snip.js
+++ b/src/models/snip/current-snip.js
@@ -40,13 +40,6 @@ export default class CurrentSnip extends Snip {
         isSkipped && document.querySelector('[data-testid="control-button-skip-forward"]')?.click()   
     }
 
-    setCurrentTime({ prevEndTime, endTime }) {
-        const lastSetThumb = this._video.element.getAttribute('lastSetThumb')
-
-        if (lastSetThumb !== 'end') return
-        this._video.currentTime = Math.max(Math.min(prevEndTime, endTime) - 5, 1)
-    }
-
     async delete() {
         const track = await this.read()
         const updatedValues = await this._store.saveTrack({ 
@@ -59,7 +52,7 @@ export default class CurrentSnip extends Snip {
     async save() {
         const track = await this.read()
         const { inputLeft, inputRight, title, artists } = this._elements
-        const { id, isSkipped, endTime: prevEndTime } = track
+        const { id, isSkipped } = track
 
         const trackId = id ?? `${title.textContent} by ${artists.textContent}`
         const result = await this._store.saveTrack({
@@ -74,9 +67,9 @@ export default class CurrentSnip extends Snip {
             },
         })
 
+        this._video.resetTempTimes()
         this.updateView()
         this.skipTrackOnSave(result)
-        this.setCurrentTime({ prevEndTime, endTime: result.endTime })
 
         await this._songTracker.updateCurrentSongData(result)
     }

--- a/src/models/snip/snip.js
+++ b/src/models/snip/snip.js
@@ -15,18 +15,14 @@ export default class Snip {
         this._controls = new SliderControls()
     }
 
-    init() {
-        this._controls.init()
-    }
+    init() { this._controls.init() }
 
     async read() {
         const track = await currentData.readTrack()
         return track
     }
 
-    reset() {
-        this._controls.setInitialValues()
-    }
+    reset() { this._controls.setInitialValues() }
 
     async _delete() {
         await this._store.deleteTrack(this._defaultTrack)
@@ -45,10 +41,7 @@ export default class Snip {
         const tempEndTime = document.getElementById('chorus-end')?.textContent
         const tempStartTime = document.getElementById('chorus-start')?.textContent
 
-        return {
-            tempEndTime: timeToSeconds(tempEndTime),
-            tempStartTime: timeToSeconds(tempStartTime),
-        }
+        return { tempEndTime: timeToSeconds(tempEndTime), tempStartTime: timeToSeconds(tempStartTime) }
     }
 
     async _share() {
@@ -66,14 +59,12 @@ export default class Snip {
 
     #toggleRemoveButton(showRemove) {
         const removeButton = document.getElementById('chorus-snip-remove-button')
-
         if (!removeButton) return
+
         removeButton.style.display = showRemove ? 'block' : 'none'
     }
 
-    #setUpdateControls(response) {
-        this._controls.updateControls(response)
-    }
+    #setUpdateControls(response) { this._controls.updateControls(response) }
 
     get _elements() {
         return {
@@ -84,11 +75,7 @@ export default class Snip {
         }
     }
 
-    displayAlert() {
-        this._alert.displayAlert()
-    }
+    displayAlert() { this._alert.displayAlert() }
 
-    _setTrackInfo({ title, artists }) {
-        setTrackInfo({ title, artists, chorusView: true })
-    }
+    _setTrackInfo({ title, artists }) { setTrackInfo({ title, artists, chorusView: true }) }
 }

--- a/src/models/snip/snip.js
+++ b/src/models/snip/snip.js
@@ -71,6 +71,7 @@ export default class Snip {
             artists: document.getElementById('track-artists'),
             inputRight: document.getElementById('input-end'),
             inputLeft: document.getElementById('input-start'),
+            loopCheckBox: document.getElementById('loop-checkbox'),
         }
     }
 

--- a/src/models/snip/snip.js
+++ b/src/models/snip/snip.js
@@ -56,7 +56,7 @@ export default class Snip {
         const pitch = preservesPitch ? 1 : 0
         const rate = parseFloat(playbackRate) * 1000
 
-        const { tempEndTime = startTime, tempStartTime = endTime } = this.tempShareTimes
+        const { tempEndTime = endTime, tempStartTime = startTime } = this.tempShareTimes
         
         const shareURL = `${this.trackURL}?ch=${tempStartTime}-${tempEndTime}-${rate}-${pitch}`
         copyToClipBoard(shareURL)

--- a/src/models/snip/snip.js
+++ b/src/models/snip/snip.js
@@ -38,8 +38,8 @@ export default class Snip {
     }
 
     get tempShareTimes() {
-        const tempEndTime = document.getElementById('chorus-end')?.textContent
-        const tempStartTime = document.getElementById('chorus-start')?.textContent
+        const tempEndTime = document.getElementById('chorus-end')?.value
+        const tempStartTime = document.getElementById('chorus-start')?.value
 
         return { tempEndTime: timeToSeconds(tempEndTime), tempStartTime: timeToSeconds(tempStartTime) }
     }
@@ -50,7 +50,6 @@ export default class Snip {
         const rate = parseFloat(playbackRate) * 1000
 
         const { tempEndTime = endTime, tempStartTime = startTime } = this.tempShareTimes
-        
         const shareURL = `${this.trackURL}?ch=${tempStartTime}-${tempEndTime}-${rate}-${pitch}`
         copyToClipBoard(shareURL)
 

--- a/src/models/video/video.js
+++ b/src/models/video/video.js
@@ -4,7 +4,6 @@ export default class VideoElement {
     constructor({ video, reverb }) {
         this._video = video
         this._reverb = reverb
-        this._isEditing = false
         this._video.crossOrigin = 'anonymous'
         this._videoOverride = new VideoOverride(this)
     }
@@ -19,14 +18,17 @@ export default class VideoElement {
 
     get active() { return this._active }
 
-    get isEditing() { return this._isEditing }
-
-    set isEditing(editing) { this._isEditing = editing }
-
     reset() {
         this.clearCurrentSpeed()
+        this.resetTempTimes()
         this.playbackRate = 1
         this.preservesPitch = true
+    }
+
+    resetTempTimes() {
+        this._video.removeAttribute('endTime')
+        this._video.removeAttribute('startTime')
+        this._video.removeAttribute('lastSetThumb')
     }
 
     get element() { return this._video }

--- a/src/observers/now-playing.js
+++ b/src/observers/now-playing.js
@@ -26,8 +26,8 @@ export default class NowPlayingObserver {
         this._seekIcons.init()
         this._loopIcon.init()
         const track = await this.setNowPlayingData()
-        this._loopIcon.highlightIcon(track)
         await this._songTracker.init()
+        this._loopIcon.highlightIcon(track)
     }
 
     #isAnchor(mutation) {

--- a/src/observers/now-playing.js
+++ b/src/observers/now-playing.js
@@ -1,6 +1,7 @@
 import { store } from '../stores/data.js'
 import { currentData } from '../data/current.js'
 
+import LoopIcon from '../models/loop-icon.js'
 import SeekIcons from '../models/seek/seek-icon.js'
 import { currentSongInfo } from '../utils/song.js'
 
@@ -13,6 +14,7 @@ export default class NowPlayingObserver {
 
         this._chorus = chorus
         this._seekIcons = new SeekIcons()
+        this._loopIcon = new LoopIcon(songTracker)
     }
 
     async observe() {
@@ -22,7 +24,9 @@ export default class NowPlayingObserver {
 
         this.#toggleSnipUI()
         this._seekIcons.init()
-        await this.setNowPlayingData()
+        this._loopIcon.init()
+        const track = await this.setNowPlayingData()
+        this._loopIcon.highlightIcon(track)
         await this._songTracker.init()
     }
 
@@ -37,6 +41,7 @@ export default class NowPlayingObserver {
     async setNowPlayingData() {
         const track = await currentData.readTrack()
         await store.setNowPlaying(track)
+        return track
     }
 
     get #songId() {
@@ -57,8 +62,12 @@ export default class NowPlayingObserver {
             this._currentSongId = this.#songId
             if (this._chorus.isShowing) this._snip.init()
 
-            await this.setNowPlayingData()
+            const track = await this.setNowPlayingData()
             await this._songTracker.songChange() 
+
+            this._loopIcon.updateIconPosition()
+            this._loopIcon.highlightIcon(track)
+
             this._snip.updateView()
             await this._seekIcons.setSeekLabels()
         }
@@ -78,6 +87,7 @@ export default class NowPlayingObserver {
     disconnect() {
         this._observer?.disconnect()
         this._currentSongId = null
+        this._loopIcon.removeIcon()
         this._seekIcons.removeIcons()
         this._songTracker.clearListeners()
         this._observer = null

--- a/src/observers/song-tracker.js
+++ b/src/observers/song-tracker.js
@@ -120,7 +120,7 @@ export default class SongTracker {
         } else if (isSnip) {
             const parsedStartTime = parseFloat(startTime) * 1000
             const currentPosition = timeToSeconds(this.#playbackPosition?.textContent || '0:00')
-            const currentPositionTime = parseFloat(currentPosition, 10) * 1000
+            const currentPositionTime = parseFloat(currentPosition) * 1000
 
             if (parsedStartTime != 0 && currentPositionTime < parsedStartTime) {
                 await this.#dispatchSeekToPosition(parsedStartTime)
@@ -152,15 +152,16 @@ export default class SongTracker {
         const { tempStartTime, tempEndTime, lastSetThumb } = this.#tempVideoAttributes
         if (!tempStartTime && !tempEndTime) return false
 
-        const tempEndTimeMS = parseFloat(tempEndTime ?? endTime) * 1000
-        const loopEndTime = lastSetThumb == 'start' ? tempEndTimeMS : tempEndTimeMS + 3000
+        const tempEndTimeMS = (parseFloat(tempEndTime ?? endTime) * 1000) - 100
+        const thumbSet = !!lastSetThumb
+        const loopEndTime = (!thumbSet || lastSetThumb == 'start') ? tempEndTimeMS : tempEndTimeMS + 3000
 
         return !Number.isNaN(tempEndTimeMS) && currentTimeMS > Math.min(loopEndTime, endTime * 1000)
     }
 
     #atSnipSongEnd({ currentTimeMS, endTime }) {
         const isSongEnd = endTime == playback.duration()
-        const endTimeMS = parseFloat(endTime, 10) * 1000 - (isSongEnd ? 100 : 0)
+        const endTimeMS = parseFloat(endTime) * 1000 - (isSongEnd ? 100 : 0)
         return currentTimeMS >= endTimeMS
     }
 
@@ -171,7 +172,7 @@ export default class SongTracker {
 
         setTimeout(() => {
             const { isShared, isSnip, startTime, endTime, autoLoop = false } = this._currentSongState
-            const currentTimeMS = parseFloat(this._video.currentTime * 1000, 10)
+            const currentTimeMS = parseFloat(this._video.currentTime * 1000)
 
             if (this.#atTempSongEnd({ endTime, currentTimeMS })) return this.#handleEditingSnipMode(startTime)
             if (isSnip && !this.#atSnipSongEnd({ currentTimeMS, endTime })) return

--- a/src/popup/controls.js
+++ b/src/popup/controls.js
@@ -26,7 +26,7 @@ class ExtControls {
     }
 
     updateControlsState(active) {
-        document.body.style.height = active ? '118px' : '88px'
+        document.body.style.height = active ? '124px' : '88px'
 
         const mediaContainer = document.getElementById('media-controls')
         mediaContainer.style.display = active ? 'flex' : 'none'

--- a/src/popup/controls.js
+++ b/src/popup/controls.js
@@ -147,7 +147,7 @@ class ExtControls {
         if (key.startsWith('seek')) return this.#updateSeek({ key, state: result })
         if (key == 'save/unsave') return this.#updateHeart({ svg, state: result })
         if (key == 'shuffle') return this.#updateShuffle({ type, key, svg, state: result })
-        if (key == 'loop') return this.#updateLoop({ type, key, svg, state: result })
+        if (key == 'loop') return this.#updateLoop({ key, svg, state: result })
 
         if (['repeat', 'play/pause'].includes(key)) {
             const pathKey = this.#getPathKey({ type, key, result })

--- a/src/popup/controls.js
+++ b/src/popup/controls.js
@@ -42,7 +42,7 @@ class ExtControls {
         const { playBtn } = this.btns
         const { rwSpan, ffSpan } = this.spans
         const { 
-            playIcon, heartIcon, repeatIcon, shuffleIcon, blockIcon, nextIcon, previousIcon, rwIcon, ffIcon
+            loopIcon, playIcon, heartIcon, repeatIcon, shuffleIcon, blockIcon, nextIcon, previousIcon, rwIcon, ffIcon
         } = this.icons
 
         playBtn.style.backgroundColor = textColour
@@ -55,6 +55,10 @@ class ExtControls {
         blockIcon.style.stroke = textColour
         blockIcon.style.fill = textColour
         blockIcon.style.strokeWidth = 0.8
+
+        loopIcon.style.stroke = textColour
+        loopIcon.style.fill = textColour
+        loopIcon.style.strokeWidth = 0.2
 
         heartIcon.style.stroke = textColour
         heartIcon.style.strokeWidth = 2
@@ -126,6 +130,16 @@ class ExtControls {
         span.textContent = parseInt(seekValue, 10)
     }
 
+    #updateLoop({ key, svg, state }) {
+        const { textColour } = this._colours
+        svg.style.stroke = textColour
+        svg.style.fill = textColour
+
+        const span = document.getElementById(`${key}-dot`)
+        const enabled = state?.includes('remove')
+        this.#updateSpan({ span, enabled, textColour })
+    }
+
     updateIcons({ type, key, result }) {
         const btn = document.querySelector(`[role="${key}"]`)
         const svg = btn.lastElementChild
@@ -133,6 +147,7 @@ class ExtControls {
         if (key.startsWith('seek')) return this.#updateSeek({ key, state: result })
         if (key == 'save/unsave') return this.#updateHeart({ svg, state: result })
         if (key == 'shuffle') return this.#updateShuffle({ type, key, svg, state: result })
+        if (key == 'loop') return this.#updateLoop({ type, key, svg, state: result })
 
         if (['repeat', 'play/pause'].includes(key)) {
             const pathKey = this.#getPathKey({ type, key, result })
@@ -157,6 +172,7 @@ class ExtControls {
             rwBtn: document.getElementById('rw-btn'),
             nextBtn: document.getElementById('next-btn'),
             playBtn: document.getElementById('play-btn'),
+            loopBtn: document.getElementById('loop-btn'),
             heartBtn: document.getElementById('heart-btn'),
             blockBtn: document.getElementById('block-btn'),
             repeatBtn: document.getElementById('repeat-btn'),
@@ -171,6 +187,7 @@ class ExtControls {
             rwIcon: document.getElementById('rw-icon'),
             playIcon: document.getElementById('play-icon'),
             nextIcon: document.getElementById('next-icon'),
+            loopIcon: document.getElementById('loop-icon'),
             heartIcon: document.getElementById('heart-icon'),
             blockIcon: document.getElementById('block-icon'),
             repeatIcon: document.getElementById('repeat-icon'),

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -23,7 +23,12 @@ PORT.onMessage.addListener(async ({ type, data }) => {
     await setCoverImage(data)
 
     if (type == 'controls') extControls.updateIcons({ type, ...data } )
-    if (type == 'state') extControls.updateUIState({ type, data })
+    if (type == 'state') { 
+        extControls.updateUIState({ type, data })
+        const popupState = await getState('popup-ui')
+        await setState({ key: 'popup-ui', values: { ...popupState, controls: data }})
+    }
+
     if (type == 'ui-state') {
         const enabled = await getState('enabled')
         await initializeUI({ active: data.active, enabled, callback: loadExtOffState })
@@ -96,6 +101,7 @@ async function setupFromStorage() {
     if (!data) return { data: null, loaded: false }
 
     loadImageData(data) 
+    data?.controls && extControls.updateUIState({ type: 'state', data: data.controls })
     return { loaded: true, data }
 }
 

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -71,11 +71,12 @@ async function setCoverImage({ cover, title, artists }) {
 
 async function loadImage({ url, elem }) {
     return new Promise((resolve, reject) => {
-        elem.onload = () => resolve(elem)
-        elem.onerror = reject
+        elem.src = url
         elem.crossOrigin = 'Anonymous'
         elem.style.transform = 'unset'
-        elem.src = url
+
+        elem.onload = () => resolve(elem)
+        elem.onerror = reject
     })
 }
 

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -22,7 +22,8 @@ export const SVG_PATHS = {
     heart: '<path d="M15.724 4.22A4.313 4.313 0 0 0 12.192.814a4.269 4.269 0 0 0-3.622 1.13.837.837 0 0 1-1.14 0 4.272 4.272 0 0 0-6.21 5.855l5.916 7.05a1.128 1.128 0 0 0 1.727 0l5.916-7.05a4.228 4.228 0 0 0 .945-3.577z"/>',
     shuffle: '<path d="M13.151.922a.75.75 0 1 0-1.06 1.06L13.109 3H11.16a3.75 3.75 0 0 0-2.873 1.34l-6.173 7.356A2.25 2.25 0 0 1 .39 12.5H0V14h.391a3.75 3.75 0 0 0 2.873-1.34l6.173-7.356a2.25 2.25 0 0 1 1.724-.804h1.947l-1.017 1.018a.75.75 0 0 0 1.06 1.06L15.98 3.75 13.15.922zM.391 3.5H0V2h.391c1.109 0 2.16.49 2.873 1.34L4.89 5.277l-.979 1.167-1.796-2.14A2.25 2.25 0 0 0 .39 3.5z"/><path d="m7.5 10.723.98-1.167.957 1.14a2.25 2.25 0 0 0 1.724.804h1.947l-1.017-1.018a.75.75 0 1 1 1.06-1.06l2.829 2.828-2.829 2.828a.75.75 0 1 1-1.06-1.06L13.109 13H11.16a3.75 3.75 0 0 1-2.873-1.34l-.787-.938z"/>',
     repeat: '<path d="M0 4.75A3.75 3.75 0 0 1 3.75 1h8.5A3.75 3.75 0 0 1 16 4.75v5a3.75 3.75 0 0 1-3.75 3.75H9.81l1.018 1.018a.75.75 0 1 1-1.06 1.06L6.939 12.75l2.829-2.828a.75.75 0 1 1 1.06 1.06L9.811 12h2.439a2.25 2.25 0 0 0 2.25-2.25v-5a2.25 2.25 0 0 0-2.25-2.25h-8.5A2.25 2.25 0 0 0 1.5 4.75v5A2.25 2.25 0 0 0 3.75 12H5v1.5H3.75A3.75 3.75 0 0 1 0 9.75v-5z"/>',
-    repeat1: '<path d="M0 4.75A3.75 3.75 0 0 1 3.75 1h.75v1.5h-.75A2.25 2.25 0 0 0 1.5 4.75v5A2.25 2.25 0 0 0 3.75 12H5v1.5H3.75A3.75 3.75 0 0 1 0 9.75v-5zM12.25 2.5h-.75V1h.75A3.75 3.75 0 0 1 16 4.75v5a3.75 3.75 0 0 1-3.75 3.75H9.81l1.018 1.018a.75.75 0 1 1-1.06 1.06L6.939 12.75l2.829-2.828a.75.75 0 1 1 1.06 1.06L9.811 12h2.439a2.25 2.25 0 0 0 2.25-2.25v-5a2.25 2.25 0 0 0-2.25-2.25z"/><path d="M9.12 8V1H7.787c-.128.72-.76 1.293-1.787 1.313V3.36h1.57V8h1.55z"/>'
+    repeat1: '<path d="M0 4.75A3.75 3.75 0 0 1 3.75 1h.75v1.5h-.75A2.25 2.25 0 0 0 1.5 4.75v5A2.25 2.25 0 0 0 3.75 12H5v1.5H3.75A3.75 3.75 0 0 1 0 9.75v-5zM12.25 2.5h-.75V1h.75A3.75 3.75 0 0 1 16 4.75v5a3.75 3.75 0 0 1-3.75 3.75H9.81l1.018 1.018a.75.75 0 1 1-1.06 1.06L6.939 12.75l2.829-2.828a.75.75 0 1 1 1.06 1.06L9.811 12h2.439a2.25 2.25 0 0 0 2.25-2.25v-5a2.25 2.25 0 0 0-2.25-2.25z"/><path d="M9.12 8V1H7.787c-.128.72-.76 1.293-1.787 1.313V3.36h1.57V8h1.55z"/>',
+    loop: '<path xmlns="http://www.w3.org/2000/svg" d="m16 28.0063c-4.6831 0-8.49375-3.8075-8.5-8.4894-.005-.4138.02437-5.6125 4.245-9.91878.3962-.40437.8162-.78749 1.2575-1.14874-2.55-.96375-5.92312-1.44938-9.5025-1.44938-.82812 0-1.5-.67188-1.5-1.5s.67188-1.5 1.5-1.5c4.8675 0 9.2506.83875 12.5106 2.50062 3.2563-1.65375 7.6325-2.48812 12.4894-2.48812.8281 0 1.5.67188 1.5 1.5 0 .82813-.6719 1.5-1.5 1.5-3.5712 0-6.9388.48312-9.485 1.44187.4337.35563.8456.73188 1.2356 1.13 4.2219 4.30563 4.2544 9.50443 4.25 9.92003v.0025c-.0006 4.6862-3.8137 8.4994-8.5006 8.4994zm.0081-18.04255c-.7818.51185-1.4887 1.08995-2.12 1.73435-3.4331 3.5025-3.3887 7.7356-3.3881 7.7781v.0301c0 3.0325 2.4675 5.5 5.5 5.5s5.5-2.4675 5.5-5.5v-.0388c0-.1538-.0406-4.3962-3.43-7.8219-.6163-.6231-1.3037-1.1837-2.0619-1.68185z"/>'
 }
 
 const seekPosition = { ff: 'left:50%', rw: 'right:50%' }
@@ -34,7 +35,7 @@ const createIcon = ({ type, id = '', role = '', lw = 20, viewBox = '-4 -4 24 24'
         style="position:relative;padding:0;border:none;background:none;display:flex;justify-content:center;align-items:center;cursor:pointer;${styles}"
     > 
         ${id !== '' ? `<span id="seek-${id}" style="position:absolute;z-index:-10;background:transparent;font-weight:bold;font-size:small;top:46%;text-align:center;${seekPosition[id]}">10</span>` : ''}
-        ${['repeat', 'shuffle'].includes(type) 
+        ${['repeat', 'shuffle', 'loop'].includes(type) 
             ? `<span style="display:none;position:absolute;height:0;bottom:6px" id="${type}-dot">&bull;</span>` : ''
         }
         <svg
@@ -57,7 +58,7 @@ const generateMediaIcons = () => `
     ${createIcon({ type: 'shuffle' })}
     ${createIcon({ type: 'seek', role: 'seek-rewind', id: 'rw', viewBox: '0 0 64 64' })}
     ${createIcon({ type: 'previous', lw: 24 })}
-    ${createIcon({ type: 'play', role: 'play/pause', styles: 'border-radius:32px;width:32px;height:32px' })}
+    ${createIcon({ type: 'play', role: 'play/pause', styles: 'border-radius:28px;width:28px;height:28px' })}
     ${createIcon({ type: 'next', lw: 24 })}
     ${createIcon({ type: 'seek', role: 'seek-fastforward', id: 'ff', viewBox: '0 0 64 64' })}
     ${createIcon({ type: 'repeat', lw: 24 })}
@@ -75,9 +76,10 @@ export const createRootContainer = () => `
         </div>
 
         <div id="media-controls" style="display:flex;width:100%;height:32px;align-items:center;justify-content:space-between">
-            <div id="left-controls" style="display:flex;justify-content:space-between;width:40px;margin-right:20px;">
-                ${createIcon({ type: 'heart', role: 'save/unsave', lw: 24, viewBox: '-5 -5 24 24' })}
-                ${createIcon({ type: 'block', role: 'block-track', lw: 24, viewBox: '-3 -3 24 24' })}
+            <div id="left-controls" style="display:flex;justify-content:space-between;margin-right:10px;">
+                ${createIcon({ type: 'heart', role: 'save/unsave', lw: 22, viewBox: '-3 -5 24 24' })}
+                ${createIcon({ type: 'block', role: 'block-track', lw: 22, viewBox: '-1 -3 24 24' })}
+                ${createIcon({ type: 'loop', lw: 20, viewBox: '0 -2 32 32' })}
             </div>
             <div id="right-controls" style="display:flex;width:100%;justify-content:center;align-items:center">
                 <div style="display:flex;width:100%;justify-content:space-between;align-items:center">

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -75,7 +75,7 @@ export const createRootContainer = () => `
             </div>
         </div>
 
-        <div id="media-controls" style="display:flex;width:100%;height:32px;align-items:center;justify-content:space-between">
+        <div id="media-controls" style="display:flex;width:100%;margin-top:8px;align-items:center;justify-content:space-between">
             <div id="left-controls" style="display:flex;justify-content:space-between;margin-right:10px;">
                 ${createIcon({ type: 'heart', role: 'save/unsave', lw: 22, viewBox: '-3 -5 24 24' })}
                 ${createIcon({ type: 'block', role: 'block-track', lw: 22, viewBox: '-1 -3 24 24' })}

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -8,7 +8,7 @@ const coverImage = () => `
 
 const trackText = id => `
     <div class="container" style="max-width:200px">
-        <div class="track-text" id="${id}" style="font-size:14px;font-weight:500"></div>
+        <div class="track-text" id="${id}" style="font-size:14px;font-weight:600"></div>
     </div>
 `
 

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -2,8 +2,8 @@ import { extToggle } from './toggle.js'
 
 const coverImage = () => `
     <canvas id="canvas" style="display:none"></canvas>
-    <img id="cover" loading="eager" style="height:64px;width:64px;" />
-    <img id="double" loading="eager" style="display:none;height:64px;width:64px" />
+    <img id="cover" loading="eager" height="64" width="64" />
+    <img id="double" loading="eager" style="display:none;" height="64" width="64" />
 `
 
 const trackText = id => `

--- a/src/stores/cache.js
+++ b/src/stores/cache.js
@@ -1,8 +1,6 @@
 export default class CacheStore {
     #cache
-    constructor() {
-        this.#cache = sessionStorage
-    }
+    constructor() { this.#cache = sessionStorage }
 
     getKey(key) {
         const result = this.#cache.getItem(key)
@@ -25,9 +23,5 @@ export default class CacheStore {
         return this.getKey(key)
     }
 
-    removeKey(key) {
-        if (!this.getKey(key)) return
-
-        this.#cache.removeItem(key)
-    }
+    removeKey(key) { this.#cache.removeItem(key) }
 }

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -40,7 +40,7 @@ class DataStore {
             detail: { key: 'now-playing', values: { id, title, artists, cover, duration , ...track, } },
         })
 
-        this.#cache.update({ key: 'now-playing', value: { id, duration, title, artists, cover, ...track } })
+        this.#cache.update({ key: 'now-playing', value: { id, duration, title, artists, cover, autoLoop: false, ...track } })
         return this.#cache.getKey(id)    
     }
 

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -15,27 +15,20 @@ class DataStore {
     }
 
     async populate() {
-        const response = await this.#dispatcher.sendEvent({
-            eventType: 'storage.populate',
-            detail: {},
-        })
+        const response = await this.#dispatcher.sendEvent({ eventType: 'storage.populate', detail: {} })
 
         Object.keys(response).forEach(key => {
             const value = response[key]
 
             if (!DO_NOT_INCLUDE.includes(key) && !value.hasOwnProperty('isSkipped')) {
-                const endTime = value?.endTime
-                value.isSkipped = endTime == 0
+                value.isSkipped = value?.endTime == 0
             }
 
             this.#cache.update({ key, value: typeof value !== 'string' ? JSON.stringify(value) : value })
         })
     }
 
-    getTrack({ id, value = {}}) {
-        const cacheValue = this.#cache.getValue({ key: id, value })
-        return cacheValue
-    }
+    getTrack({ id, value = {}}) { return this.#cache.getValue({ key: id, value }) }
 
     async setNowPlaying(track) {
         const { id, cover } = currentSongInfo() 
@@ -57,17 +50,10 @@ class DataStore {
         return true
     }
 
-    getReverb() {
-        const cacheValue = this.#cache.getValue({ key: 'reverb', value: 'none' })
-        return cacheValue
-    }
+    getReverb() { return this.#cache.getValue({ key: 'reverb', value: 'none' }) }
 
     async saveReverb(effect) {
-        await this.#dispatcher.sendEvent({
-            eventType: 'storage.set',
-            detail: { key: 'reverb', values: effect },
-        })
-
+        await this.#dispatcher.sendEvent({ eventType: 'storage.set', detail: { key: 'reverb', values: effect } })
         this.#cache.update({ key: 'reverb', value: effect })
         return this.#cache.getKey(id)
     }
@@ -79,10 +65,7 @@ class DataStore {
         if (isTrack && this.#shouldDeleteTrack(value)) {
             await this.deleteTrack(id)
         } else {
-            response = await this.#dispatcher.sendEvent({
-                eventType: 'storage.set',
-                detail: { key: id, values: value },
-            })
+            response = await this.#dispatcher.sendEvent({ eventType: 'storage.set', detail: { key: id, values: value } })
         }
 
         this.#cache.update({ key: id, value: response ?? value })
@@ -90,10 +73,8 @@ class DataStore {
     }
 
     async deleteTrack(id) {
-        await this.#dispatcher.sendEvent({
-            eventType: 'storage.delete',
-            detail: { key: id },
-        })
+        await this.#dispatcher.sendEvent({ eventType: 'storage.delete', detail: { key: id } })
+        this.#cache.removeKey(id)
     }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -311,6 +311,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 [role=ff][aria-label],
 [role=rw][aria-label],
+[role=loop][aria-label],
 [role=skip][aria-label],
 [role=snip][aria-label], 
 [role=speed][aria-label],
@@ -322,6 +323,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 [role=ff][aria-label]:after,
 [role=rw][aria-label]:after,
+[role=loop][aria-label]:after,
 [role=skip][aria-label]:after,
 [role=snip][aria-label]:after, 
 [role=speed][aria-label]:after, 
@@ -352,6 +354,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 [role=ff][aria-label]:hover:after,
 [role=rw][aria-label]:hover:after,
+[role=loop][aria-label]:hover:after,
 [role=skip][aria-label]:hover:after,
 [role=snip][aria-label]:hover:after, 
 [role=speed][aria-label]:hover:after,

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,11 +56,16 @@
     width: 320px;
 }
 
-#chorus button,
-#chorus input {
-    border-width: 0 !important;
-    border-style: solid !important;
-    border-color: #e5e7eb;
+#chorus {
+    button, input {
+        border-width: 0 !important;
+        border-style: solid !important;
+        border-color: #e5e7eb;
+    }
+
+    button {
+        cursor: pointer !important;
+    }
 }
 
 .success {
@@ -162,14 +167,14 @@ input[type=number]::-webkit-outer-spin-button {
 
 .slider-container {
     position: relative;
-    width: 100%;
-    margin: 0 8px;
+    flex-grow: 1;
+    margin: 0 10px;
 }
 
 .slider {
     position: relative;
     z-index: 1;
-    height: 6px;
+    height: 4px;
 }
 
 .slider>.track {
@@ -201,8 +206,8 @@ input[type=number]::-webkit-outer-spin-button {
 .slider>.thumb {
     position: absolute;
     z-index: 3;
-    width: 12px;
-    height: 12px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background-color: #fff;
     box-shadow: 0 0 0 0 rgba(98, 0, 238, .1);
@@ -211,13 +216,13 @@ input[type=number]::-webkit-outer-spin-button {
 
 .slider>.thumb.left {
     left: 25%;
-    transform: translate(-6px, -3px);
+    transform: translate(-4px, -2px);
     display: none;
 }
 
 .slider>.thumb.right {
     right: 25%;
-    transform: translate(6px, -3px);
+    transform: translate(4px, -2px);
     display: none;
 }
 
@@ -236,7 +241,7 @@ input[type=number]::-webkit-outer-spin-button {
     appearance: none;
     z-index: 2;
     margin: 0;
-    height: 6px;
+    height: 4px;
     width: 100%;
     opacity: 0;
 }
@@ -275,10 +280,9 @@ input[type=number]::-webkit-outer-spin-button {
     margin-block: 0px;
     font-size: 0.6875rem;
     width: fit-content;
-    min-width: 30px;
+    min-width: 25px;
     font-weight: 400;
     color: #b3b3b3;
-    padding-top: 2px;
 }
 
 .chorus-icon-active,
@@ -290,7 +294,7 @@ input[type=number]::-webkit-outer-spin-button {
     display: flex;
     height: 1.5rem;
     margin: 12px 0;
-    justify-content: space-evenly;
+    justify-content: space-between;
     align-items: center;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,15 +56,15 @@
     width: 320px;
 }
 
+button {
+    cursor: pointer !important;
+}
+
 #chorus {
     button, input {
         border-width: 0 !important;
         border-style: solid !important;
         border-color: #e5e7eb;
-    }
-
-    button {
-        cursor: pointer !important;
     }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -390,8 +390,8 @@ hr {
 
 .track-text {
     padding: 0;
-    font-size: 14px;
-    font-weight: 500;
+    font-size: 16px;
+    font-weight: 600;
 }
 
 @keyframes marquee {

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,6 +37,10 @@
     font-size: 20px;
 }
 
+#header-buttons button:hover {
+    outline: solid 1px #fff;
+}
+
 #chorus-main {
     border: 1px solid #282828;
     border-right: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -34,7 +34,7 @@
 .chorus-header {
     color: #f0f0f0;
     font-weight: 600;
-    line-height: 1;
+    font-size: 20px;
 }
 
 #chorus-main {
@@ -54,6 +54,7 @@
     bottom: 80px;
     background-color: #171717;
     width: 320px;
+    height: 246px;
 }
 
 button {
@@ -61,11 +62,13 @@ button {
 }
 
 #chorus {
-    button, input {
+    button {
         border-width: 0 !important;
         border-style: solid !important;
         border-color: #e5e7eb;
     }
+
+    input { border: none }
 }
 
 .success {
@@ -125,7 +128,7 @@ button {
 .chorus-text {
     color: #fff;
     font-weight: 600;
-    font-size: .75rem;
+    font-size: .85rem;
 }
 
 .chorus-pill {
@@ -293,7 +296,7 @@ input[type=number]::-webkit-outer-spin-button {
 .snippy {
     display: flex;
     height: 1.5rem;
-    margin: 12px 0;
+    margin: 8px 0;
     justify-content: space-between;
     align-items: center;
 }
@@ -382,7 +385,8 @@ hr {
 }
 
 .track-text {
-    font-size: 16px;
+    padding: 0;
+    font-size: 14px;
     font-weight: 500;
 }
 

--- a/src/utils/higlight.js
+++ b/src/utils/higlight.js
@@ -21,14 +21,16 @@ export const highlightElement = ({
         if (!element) return
 
         const fillColor = isHighlightable(songStateData) ? '#1ed760' : 'currentColor'
-        element.style[property] = fillColor
+        element.setAttribute(property, fillColor)
     }, 250)
 }
 
 export const highlightLoopIcon = highlight => {
-    const group = document.getElementById('loop-group')
-    if (!group) return
+    const svgIcon = document.getElementById('loop-icon')
+    if (!svgIcon) return
 
-    group.style.stroke = highlight ? '#1ed760' : 'currentColor'
+    const colour = highlight ? '#1ed760' : 'currentColor'
+    svgIcon.setAttribute('fill', colour)
+    svgIcon.setAttribute('stroke', colour)
 }
 

--- a/src/utils/higlight.js
+++ b/src/utils/higlight.js
@@ -24,3 +24,11 @@ export const highlightElement = ({
         element.style[property] = fillColor
     }, 250)
 }
+
+export const highlightLoopIcon = highlight => {
+    const group = document.getElementById('loop-group')
+    if (!group) return
+
+    group.style.stroke = highlight ? '#1ed760' : 'currentColor'
+}
+

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -1,6 +1,9 @@
 async function getActiveTab() {
-    const result = await chrome.tabs.query({ url: ['*://open.spotify.com/*'] })
-    return result?.at(0)
+    const currentWindow = await chrome.tabs.query({ active: true, currentWindow: true, url: ['*://open.spotify.com/*'] })
+    if (currentWindow.length) return currentWindow.at(0)
+
+    const anyWindow = await chrome.tabs.query({ url: ['*://open.spotify.com/*'] })
+    return anyWindow?.at(0)
 }
 
 async function activeOpenTab() {

--- a/src/utils/selectors.js
+++ b/src/utils/selectors.js
@@ -9,6 +9,7 @@ const mediaKeys = {
 }
 
 const chorusKeys = {
+    'loop': '#loop-button',
     'settings': '#chorus-icon',
     'block-track': '#chorus-skip',
     'seek-rewind': '#seek-player-rw-button',

--- a/src/utils/song.js
+++ b/src/utils/song.js
@@ -1,5 +1,11 @@
 import { timeToSeconds } from './time.js'
 
+const getImage = imageSrc => {
+    if (!imageSrc) return undefined
+
+    return imageSrc?.replace('4851', 'b273')
+}
+
 export const currentSongInfo = () => {
     const songLabel = document.querySelector('[data-testid="now-playing-widget"]')?.getAttribute('aria-label')
     const image = document.querySelector('[data-testid="CoverSlotCollapsed__container"] img')
@@ -8,15 +14,16 @@ export const currentSongInfo = () => {
 
     // Remove 'Now playing: ' prefix
     const id = songLabel?.split('Now playing: ')?.at(1)
+    const cover = getImage(image?.src)
 
-    if (!contextType) return { id, cover: image?.src }
+    if (!contextType) return { id, cover }
 
     const params = new URLSearchParams(anchor?.href)
     const trackId = params?.get('uri')?.split(`${contextType}:`).at(1)
 
     return  {
         id,
-        cover: image?.src,
+        cover,
         ...contextType && {
             type: contextType,
             trackId, 
@@ -40,8 +47,8 @@ export const trackSongInfo = row => {
     return {
         title,
         startTime: 0,
-        cover: image?.src,
         artists: getArtists(row),
+        cover: getImage(image?.src),
         id: `${title} by ${artists}`,
         endTime: timeToSeconds(songLength),
         ...trackInfo && {...trackInfo }
@@ -53,18 +60,13 @@ const getTrackId = row => {
     if (!trackIdUrl) return
 
     const url = trackIdUrl.split('.com').at(1)
-    return {
-        url,
-        trackId: url.split('/').at(2)
-    }
+    return { url, trackId: url.split('/').at(2) }
 }
 
 const getArtists = row => {
     const artistsList = row.querySelectorAll('span > div > a')
     // Here means we are at artist page and can get name from h1
-    if (!artistsList.length) {
-        return document.querySelector('span[data-testid="entityTitle"] > h1')?.textContent || ''
-    }
+    if (!artistsList.length) return document.querySelector('span[data-testid="entityTitle"] > h1')?.textContent || ''
 
     return Array.from(artistsList).filter(artist => artist.href.includes('artist')).map(artist => artist.textContent).join(', ')
 }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -23,6 +23,23 @@ export const secondsToTime = seconds => {
     return time
 }
 
+export const formatTimeInSeconds = totalSeconds => {
+    const parsedSeconds = parseFloat(totalSeconds)
+
+    if (isNaN(parsedSeconds) || parsedSeconds < 0) return
+
+    const hours = `${Math.floor(parsedSeconds / 3600)}`.padStart(2, '0')
+    const minutes = `${Math.floor((parsedSeconds % 3600) / 60)}`.padStart(2, '0')
+    const seconds = `${Math.floor(parsedSeconds % 60)}`.padStart(2, '0')
+    const milliseconds = `${Math.round((parsedSeconds % 1) * 1000)}`.padStart(3, '0').slice(0, 2)
+
+    return `${hours}:${minutes}:${seconds}:${milliseconds}`
+}
+
+export const timeToMilliseconds = ({ hours, mins, secs, ms }) => (
+    Number(hours) * 3600 * 1000 + Number(mins) * 60 * 1000 + Number(secs) * 1000 + Number(ms)
+)
+
 export const timeToSeconds = time => {
     if (!time || !time?.includes(':')) return
 
@@ -34,6 +51,9 @@ export const timeToSeconds = time => {
     } else if (timeParts.length === 2) {
         const [minutes, seconds ] = timeParts
         return minutes * 60 + seconds
+    } else if (timeParts.length === 4) {
+        const [hours, minutes, seconds, milliseconds] = timeParts;
+        return (hours || 0) * 3600 + minutes * 60 + seconds + milliseconds / 100;
     }
 
     return timeParts.at(0)


### PR DESCRIPTION
PR improves upon current snip controls:

1. More precise slider controls (update to 0.01 step for settings milliseconds of snip)
2. Update currentTime value after ~250ms after slider has not been updated. Instantaneous for manual inputs.
3. New manual inputs for setting start and end times (again - up to milliseconds of snip). Follows HH:MM:SS:MS notation.
4. Separate looping logic and icon from Spotify's repeat-1
5. Add loop icon to popup ui
6. Add loop option to shortcut keys command

<img width="722" alt="image" src="https://github.com/cdrani/chorus/assets/18746599/160b6a86-dc0c-4e33-8c92-c8d9d50b7945">

---

closes #192, closes #193