### PR TITLE
fix: artist-disco service when album is set to null

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "short_name": "Chorus",
   "name": "Chorus - Spotify Enhancer",
   "description": "Enhance Spotify with controls to save favourite snips, auto-skip tracks, and set global and custom speed. More to come!",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "manifest_version": 3,
   "author": "cdrani",
   "action": {

--- a/src/services/artist-disco.js
+++ b/src/services/artist-disco.js
@@ -38,7 +38,7 @@ async function fetchTrackURIs(albumIds) {
         const url = generateURL({ pathType: 'albums', param: albumIdsGroup.join(',') })
         const options = await setOptions({})
         const albumInfo = await request({ url, options })
-        const albumGroupsTracks = albumInfo?.albums?.map(({ tracks }) => tracks)
+        const albumGroupsTracks = albumInfo?.albums?.map(album => album?.tracks ?? null).filter(Boolean)
 
         for (const album of albumGroupsTracks) {
             album.items.forEach(({ uri }) => trackURIs.push(uri))
@@ -82,10 +82,8 @@ async function createArtistDiscoPlaylist({ artist_name, artist_id }) {
             const playlist = await createPlaylist(artist_name)
             await addTracksToPlaylist({ playlist, trackURIs })
             resolve({ artist_name, playlist })
-        } catch (error) {
-            reject(error)
-        }
-    });
+        } catch (error) { console.error(error); reject(error) }
+    })
 }
 
 export { createArtistDiscoPlaylist }


### PR DESCRIPTION
PR aims to fix issue on Artist Discography playlist creation. The unique scenario mentioned in the issue was due to an artist like "**Steppenwolf**" having exactly 20 albums + singles combined, which results in two grouped album infos. One group would contain the 20 albums + singles array, but the second group would return an array with a single item set to null (`[null]`), which was not accounted for as it was yet to been seen.


closes #203 