### PR TITLE
fix: chunk file generation for Windows: ensure [name]-[hash].js naming

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,13 @@
+import path from 'path'
 import { chromeExtension, simpleReloader } from 'rollup-plugin-chrome-extension'
 
 export default {
     input: 'src/manifest.chrome.json',
     output: {
         dir: 'dist',
-        format: 'esm'
+        format: 'esm',
+        chunkFileNames: path.join('chunks', '[name]-[hash].js')
+
         // sourcemap: true
     },
     plugins: [chromeExtension(), simpleReloader()]

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -108,7 +108,7 @@ async function setupFromStorage() {
 function loadDefaultUI({ enabled, active }) {
     const { chorusPopup, cover } = getElements()
 
-    cover.src = '../icons/logo.png'
+    cover.src = chrome.runtime.getURL('../icons/logo.png')
     cover.style.transform = 'scale(1.15)'
 
     const title =


### PR DESCRIPTION
[FIX]: Extension not working on Windows 

Resolves #217 