### PR TITLE
fix: create click outside util function to hide ui

### DIFF
--- a/src/events/listeners/header-listeners.js
+++ b/src/events/listeners/header-listeners.js
@@ -12,6 +12,10 @@ export default class HeaderListeners extends Listeners {
     }
 
     init() {
+        if (this._viewInFocus == 'fx' && this._setup) {
+            return this._reverb.init()
+        }
+
         if (this._setup) return
 
         this.#snipViewToggle()
@@ -40,6 +44,7 @@ export default class HeaderListeners extends Listeners {
     set currentView(selectedView = 'snip') {
         this._viewInFocus = selectedView
         if (selectedView != 'snip') this._video.resetTempTimes()
+        this._reverb.destroyClickHandlers()
 
         this._VIEWS.forEach((view) => {
             const viewButton = document.getElementById(`chorus-${view}-button`)

--- a/src/events/listeners/listeners.js
+++ b/src/events/listeners/listeners.js
@@ -17,5 +17,6 @@ export default class Listeners {
         const mainElement = document.getElementById('chorus-main')
         mainElement.style.display = 'none'
         this._video.resetTempTimes()
+        this._reverb.destroyClickHandlers()
     }
 }

--- a/src/models/now-playing-icons.js
+++ b/src/models/now-playing-icons.js
@@ -58,14 +58,21 @@ export default class NowPlayingIcons {
         return createIcon(NOW_PLAYING_SKIP_ICON)
     }
 
+    #showModal() {
+        this.chorus.show()
+        this.snip.init()
+        this.snip.updateView()
+    }
+
+    async #hideModal() {
+        await this.chorus.hide()
+    }
+
     #setIconListeners() {
         const settingsIcon = document.getElementById('chorus-icon')
-        settingsIcon?.addEventListener('click', () => {
-            this.chorus.toggle()
-            if (this.chorus.isShowing) {
-                this.snip.init()
-                this.snip.updateView()
-            }
+        settingsIcon?.addEventListener('click', async (e) => {
+            e.preventDefault()
+            this.chorus.isShowing ? await this.#hideModal() : this.#showModal()
         })
 
         const skipIcon = document.getElementById('chorus-skip')
@@ -106,7 +113,7 @@ export default class NowPlayingIcons {
 
         if (updatedValues.isSkipped) {
             this.#highlightTrackListBlock(updatedValues)
-            document.querySelector('[data-testid="control-button-skip-forward"]')?.click()   
+            document.querySelector('[data-testid="control-button-skip-forward"]')?.click()
         }
     }
 }

--- a/src/models/tracklist/track-list.js
+++ b/src/models/tracklist/track-list.js
@@ -190,7 +190,7 @@ export default class TrackList {
                     this._chorus.show()
                     await this._trackSnip.init(row)
                 } else if (currentIndex == this._previousRowNum) {
-                    this._chorus.toggle()
+                    await this._chorus.toggle()
                 }
 
                 const icon = row.querySelector('button[role="snip"]')

--- a/src/utils/click-outside.js
+++ b/src/utils/click-outside.js
@@ -1,0 +1,16 @@
+export function clickOutside({ area, node }) {
+    const handleClick = (event) => {
+        if (!node?.contains(event.target) && !event.defaultPrevented) {
+            node.dispatchEvent(new CustomEvent('click_outside', { detail: node }))
+        }
+    }
+
+    const boundary = document.querySelector(area) ?? document
+    boundary.addEventListener('click', handleClick, false)
+
+    return {
+        destroy() {
+            boundary.removeEventListener('click', handleClick, false)
+        }
+    }
+}


### PR DESCRIPTION
Click Outside util to to "close" ui when clicked outside of an area/boundary. Currently used for chorus modal + reverb preset selection dropdowns. This works in conjunction with clicking the ui again to toggle the view of the chorus modal or the dropdown trigger buttons.

closes #207 